### PR TITLE
Added __str__ support for print

### DIFF
--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -337,7 +337,16 @@ batavia.builtins.pow = function(args) {
 };
 
 batavia.builtins.print = function(args, kwargs) {
-    batavia.stdout(args.join(' ') + '\n');
+    var elements = [], print_value;
+    args.map(function(elm) {
+        elements.push(elm.__str__ ? elm.__str__() : elm.toString());
+    });
+    // Python prints (obj, obj, obj) when more than one object is being printed
+    print_value = elements.join(', ');
+    if (elements.length > 1) {
+        print_value = "(" + print_value + ")";
+    }
+    batavia.stdout(print_value + "\n");
 };
 
 batavia.builtins.property = function() {


### PR DESCRIPTION
We now prefer \__str__ when printing, fallback to toString.

Also fixed output to match python print, when multiple objects are
present, such that 
```
a = {'a':1, 'b': 2}
b = "foo"
c = 5
print(a,b,c) 
```
will produce:
```
({a: 1, b: 2}, foo, 5)
```
*Note the missing ' from the string literal is missing in the toString function of String.*