### PR TITLE
Implement `delattr`

### DIFF
--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -123,8 +123,26 @@ batavia.builtins.credits = function() {
     console.log("Thanks to all contributors, including those in AUTHORS, for supporting Batavia development. See https://github.com/pybee/batavia for more information");
 };
 
-batavia.builtins.delattr = function() {
-    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'delattr' not implemented");
+batavia.builtins.delattr = function(args) {
+    if (args) {
+        try {
+            if (batavia.builtins.getattr(args)) {
+                delete args[0][args[1]]
+                // False returned by bool(delattr(...)) in the success case
+                return false
+            }
+        } catch (err) {
+            // This is maybe unecessary, but matches the error thrown by python 3.5.1 in this case
+            if (err instanceof batavia.builtins.AttributeError) {
+                throw new batavia.builtins.AttributeError(args[1])
+            }
+            if (err instanceof batavia.builtins.TypeError) {
+                throw new batavia.builtins.TypeError("delattr expected 2 arguments, got " + args.length)
+            }
+        }
+    } else {
+        throw new batavia.builtins.TypeError("delattr expected 2 arguments, got 0")
+    }
 };
 
 batavia.builtins.dict = function() {

--- a/testserver/sample.py
+++ b/testserver/sample.py
@@ -20,6 +20,7 @@ def do_stuff(count, size=3):
         print("HELLO", i)
         other.wiggle(i)
 
+
 def try_builtins():
     print('sum(0,1,2,3,4)', sum(0,1,2,3,4))
     print('abs(-1)', abs(-1))
@@ -37,6 +38,8 @@ def try_builtins():
     print('pow(2, 3, 3)', pow(2, 3, 3))
 
     print('abs(None)', abs(None)) #known failure
+
+
 def main(argv):
     print('Use default')
     print(do_stuff(int(argv[1])))
@@ -53,6 +56,8 @@ def main(argv):
     print('Distance with kwarg is', p.distance())
     print('hasattr(p, "x")', hasattr(p, "x")) # expect true
     print('hasattr(p, "a")', hasattr(p, "a")) # expect false
+    print('delattr(p, "x")', delattr(p, "x"))
+    print('hasattr(p, "x")', hasattr(p, "x")) # now expect false
     print('Manipulate the DOM...')
     print('Open a new web page...')
     dom.window.open('http://pybee.org', '_blank')


### PR DESCRIPTION
This implementation is trying to match the interface of `delattr` in
cpython 3.5.1 as close as possible.