### PR TITLE
Documentation - setting up python 3.4 and phantomjs on raspbian. 

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -81,6 +81,7 @@ Raspbian for Raspberry Pi 1 does not come with python 3.4.  To install python 3.
 Get the source:
 
 .. code-block:: bash
+
 	$ cd /tmp
 	$ wget https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz
 	$ tar xvzf Python-3.4.1.tgz
@@ -89,6 +90,7 @@ Get the source:
 Configure and Install
 
 .. code-block:: bash
+
 	$ ./configure --prefix=/opt/python3.4
 	$ make
 	$ sudo make install

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -74,6 +74,7 @@ This has been successfully tested on Raspbian GNU/Linux 7 (wheezy)
 
 Python 3.4
 Source: `Procrastinative Ninja`_
+
 .. _Procrastinative Ninja: https://procrastinative.ninja/2014/07/20/install-python34-on-raspberry-pi
 
 Raspbian for Raspberry Pi 1 does not come with python 3.4.  To install python 3.4, you would need to first get the source and then build it:
@@ -98,6 +99,7 @@ Configure and Install
 
 Installing Phantomjs
 Source: `aeberhardo`_
+
 .. _aeberhardo: https://github.com/aeberhardo/phantomjs-linux-armv6l
 
 To install phantomjs:

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -113,6 +113,7 @@ To install phantomjs:
 Copy phantomjs to /usr/local/bin:
 
 .. code-block:: bash
+
     $ cp phantomjs /usr/local/bin/
 
 Running the test suite

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -95,11 +95,6 @@ Configure and Install
 	$ make
 	$ sudo make install
 
-.. code-block:: bash
-
-    $ cd batavia
-    $ python setup.py test
-
 
 Installing Phantomjs
 Source: `https://github.com/aeberhardo/phantomjs-linux-armv6l`_
@@ -108,16 +103,17 @@ Source: `https://github.com/aeberhardo/phantomjs-linux-armv6l`_
 To install phantomjs:
 
 .. code-block:: bash
-	wget https://github.com/aeberhardo/phantomjs-linux-armv6l/archive/master.zip #downloads phantomjs source
-	unzip master.zip
-	cd phantomjs-linux-armv6l-master
-	bunzip2 *.bz2 && tar xf *.tar
-	./phantomjs-1.9.0-linux-armv6l/bin/phantomjs --version
+
+    $ wget https://github.com/aeberhardo/phantomjs-linux-armv6l/archive/master.zip #downloads phantomjs source
+    $ unzip master.zip
+    $ cd phantomjs-linux-armv6l-master
+    $ bunzip2 *.bz2 && tar xf *.tar
+    $ ./phantomjs-1.9.0-linux-armv6l/bin/phantomjs --version
 
 Copy phantomjs to /usr/local/bin:
 
 .. code-block:: bash
-	cp phantomjs /usr/local/bin/
+    $ cp phantomjs /usr/local/bin/
 
 Running the test suite
 ----------------------

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -73,7 +73,7 @@ Raspbian/Raspberry Pi
 This has been successfully tested on Raspbian GNU/Linux 7 (wheezy)
 
 Python 3.4
-Source: `Procrastinative Ninja`_.
+Source: `Procrastinative Ninja`_
 .. _Procrastinative Ninja: https://procrastinative.ninja/2014/07/20/install-python34-on-raspberry-pi
 
 Raspbian for Raspberry Pi 1 does not come with python 3.4.  To install python 3.4, you would need to first get the source and then build it:
@@ -97,8 +97,8 @@ Configure and Install
 
 
 Installing Phantomjs
-Source: `https://github.com/aeberhardo/phantomjs-linux-armv6l`_
-.. _https://github.com/aeberhardo/phantomjs-linux-armv6l: https://github.com/aeberhardo/phantomjs-linux-armv6l
+Source: `aeberhardo`_
+.. _aeberhardo: https://github.com/aeberhardo/phantomjs-linux-armv6l
 
 To install phantomjs:
 

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -66,13 +66,51 @@ so it should be reliable.
 
 .. _downloaded here: https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2
 .. _Batavia CI server: https://travis-ci.org/pybee/batavia
-
+.. _PhantomJS: http://phantomjs.org
 Raspbian/Raspberry Pi
 ~~~~~~~~~~~~~~~~~~~~~
 
-This is apparently possible...
+This has been successfully tested on Raspbian GNU/Linux 7 (wheezy)
 
-.. _PhantomJS: http://phantomjs.org
+Python 3.4
+Source: `Procrastinative Ninja`_.
+.. _Procrastinative Ninja: https://procrastinative.ninja/2014/07/20/install-python34-on-raspberry-pi
+
+Raspbian for Raspberry Pi 1 does not come with python 3.4.  To install python 3.4, you would need to first get the source and then build it:
+
+Get the source:
+
+.. code-block:: bash
+	$ cd /tmp
+	$ wget https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz
+	$ tar xvzf Python-3.4.1.tgz
+	$ cd Python-3.4.1/
+
+Configure and Install
+
+.. code-block:: bash
+	$ ./configure --prefix=/opt/python3.4
+	$ make
+	$ sudo make install
+
+
+Installing Phantomjs
+Source: `https://github.com/aeberhardo/phantomjs-linux-armv6l`_
+.. _https://github.com/aeberhardo/phantomjs-linux-armv6l: https://github.com/aeberhardo/phantomjs-linux-armv6l
+
+To install phantomjs:
+
+.. code-block:: bash
+	wget https://github.com/aeberhardo/phantomjs-linux-armv6l/archive/master.zip #downloads phantomjs source
+	unzip master.zip
+	cd phantomjs-linux-armv6l-master
+	bunzip2 *.bz2 && tar xf *.tar
+	./phantomjs-1.9.0-linux-armv6l/bin/phantomjs --version
+
+Copy phantomjs to /usr/local/bin:
+
+.. code-block:: bash
+	cp phantomjs /usr/local/bin/
 
 Running the test suite
 ----------------------

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -95,6 +95,11 @@ Configure and Install
 	$ make
 	$ sudo make install
 
+.. code-block:: bash
+
+    $ cd batavia
+    $ python setup.py test
+
 
 Installing Phantomjs
 Source: `https://github.com/aeberhardo/phantomjs-linux-armv6l`_

--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -73,13 +73,14 @@ Raspbian/Raspberry Pi
 This has been successfully tested on Raspbian GNU/Linux 7 (wheezy)
 
 Python 3.4
-Source: `Procrastinative Ninja`_
+
+Sourced from: `Procrastinative Ninja`_
 
 .. _Procrastinative Ninja: https://procrastinative.ninja/2014/07/20/install-python34-on-raspberry-pi
 
 Raspbian for Raspberry Pi 1 does not come with python 3.4.  To install python 3.4, you would need to first get the source and then build it:
 
-Get the source:
+To get the source run:
 
 .. code-block:: bash
 
@@ -88,7 +89,7 @@ Get the source:
 	$ tar xvzf Python-3.4.1.tgz
 	$ cd Python-3.4.1/
 
-Configure and Install
+To configure and Install, run:
 
 .. code-block:: bash
 
@@ -98,11 +99,12 @@ Configure and Install
 
 
 Installing Phantomjs
-Source: `aeberhardo`_
+
+Sourced from: `aeberhardo`_
 
 .. _aeberhardo: https://github.com/aeberhardo/phantomjs-linux-armv6l
 
-To install phantomjs:
+To install phantomjs, run the following:
 
 .. code-block:: bash
 
@@ -112,7 +114,7 @@ To install phantomjs:
     $ bunzip2 *.bz2 && tar xf *.tar
     $ ./phantomjs-1.9.0-linux-armv6l/bin/phantomjs --version
 
-Copy phantomjs to /usr/local/bin:
+Lastly, copy phantomjs to /usr/local/bin:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Attempt at documenting steps to configure the prerequisites for batavia test suite on Raspbian. 