### PR TITLE
Adding line to change into correct directory

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -34,6 +34,7 @@ Then create a virtual environment and install Batavia into it:
 
     $ virtualenv -p $(which python3) env
     $ . env/bin/activate
+    $ cd batavia
     $ pip install -e .
 
 Lastly, you'll need to obtain and install `PhantomJS`_. PhantomJS is a


### PR DESCRIPTION
I got the following error when running 'pip install -e .":
`Directory '.' is not installable. File 'setup.py' not found.`

Then I cd batavia, ran pip install again and it went through this time. I guess line was missing from this doc.