### PR TITLE
Implement Polyglot error [Design Issue]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ distribute-*
 /batavia.min.js
 /tests/temp
 env
+.eggs/
+.python-version

--- a/batavia/core/Exception.js
+++ b/batavia/core/Exception.js
@@ -191,6 +191,13 @@ batavia.builtins.OverflowError.prototype.constructor = OverflowError;
 
 batavia.builtins.PendingDeprecationWarning = undefined;
 
+function PolyglotError(msg) {
+    batavia.builtins.BaseException.call(this, 'PolyglotError', msg);
+}
+batavia.builtins.PolyglotError = PolyglotError;
+batavia.builtins.PolyglotError.prototype = Object.create(batavia.builtins.BaseException.prototype);
+batavia.builtins.PolyglotError.prototype.constructor = PolyglotError;
+
 function ReferenceError(msg) {
     batavia.builtins.BaseException.call(this, 'ReferenceError', msg);
 }

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -581,8 +581,10 @@ batavia.builtins.hex = function(args) {
 };
 
 batavia.builtins.id = function() {
-    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'id' not implemented");
+    throw new batavia.builtins.PolyglotError("'id' has no meaning here. See docs/internals/limitations#id");
 };
+batavia.builtins.id__doc__ = 'Return the identity of an object.  This is guaranteed to be unique among simultaneously existing objects.  (Hint: it\'s the object\'s memory address.)';
+
 
 batavia.builtins.input = function() {
     throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'input' not implemented");

--- a/docs/internals/builtins.rst
+++ b/docs/internals/builtins.rst
@@ -4,6 +4,7 @@ Built-ins
 General Structure
 -------------
 
+.. code-block:: javascript
 
   // Example: a function that accepts exactly one argument, and no keyword arguments
   batavia.builtins.<fn> = function(<args>, <kwargs>) {

--- a/docs/internals/builtins.rst
+++ b/docs/internals/builtins.rst
@@ -1,0 +1,45 @@
+Built-ins
+============
+
+General Structure
+-------------
+
+
+  // Example: a function that accepts exactly one argument, and no keyword arguments
+  batavia.builtins.<fn> = function(<args>, <kwargs>) {
+      if (arguments.length != 2) {
+          throw new batavia.builtins.BataviaError("Batavia calling convention not used.");
+      }
+      if (kwargs && Object.keys(kwargs).length > 0) {
+          throw new batavia.builtins.TypeError("<fn>() doesn't accept keyword arguments.");
+      }
+      if (!args || args.length != 1) {
+          throw new batavia.builtins.TypeError("<fn>() expected exactly 1 argument (" + args.length + " given)");
+      }
+
+      // if the function only works with a specific object type, add a test
+      var obj = args[0];
+
+      if (!batavia.isinstance(obj, batavia.types.<type>)) {
+          throw new batavia.builtins.TypeError(
+              "<fn>() expects a <type> (" + batavia.type_name(obj) + " given)");
+      }
+
+      // actual code goes here
+      Javascript.Function.Stuff();
+  }
+  batavia.builtins.<fn>.__doc__ = 'docstring from Python 3.4 goes here, for documentation'
+
+
+Process
+----------
+
+For a given function, run `functionname.__doc__` in the Python 3.4 repl
+
+Copy the docstring into the doc
+
+Run the function in Python 3.4
+
+Take a guess at the implementation structure based on the other functions. 
+
+Copy the style of the other implemented functions

--- a/docs/internals/limitations.rst
+++ b/docs/internals/limitations.rst
@@ -1,0 +1,19 @@
+Limitations
+===============
+
+There are high level issues with the incompatibility of some low level Python fundamental functionality
+that do not exist in JavaScript. 
+
+These issues are detailed here. 
+
+id
+---
+
+"Return the identity of an object.
+This is guaranteed to be unique among simultaneously existing objects.
+(CPython uses the object's memory address.)"
+
+This doesn't exist in JavaScript. There's no useful information that can be returned from `id` in this instance. 
+
+
+


### PR DESCRIPTION
Some python internals have absolutely no meaning in the Batavia/JavaScript context

This PR sets up the framework for `id` being one of those things. 

@freakboy3742: your BDFN call is required. 