### PR TITLE
Added BATAVIA_MAGIC which allows for Py3.4 and Py3.5 support

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -685,14 +685,50 @@ batavia.VirtualMachine.prototype.byte_BUILD_SET = function(count) {
 };
 
 batavia.VirtualMachine.prototype.byte_BUILD_MAP = function(size) {
-    var items = this.popn(size*2);
-    var obj = {};
+    switch (batavia.BATAVIA_MAGIC) {
+        case batavia.BATAVIA_MAGIC_35:
+            var items = this.popn(size * 2);
+            var obj = {};
 
-    for(var i=0; i<items.length; i+=2) {
-        obj[items[i]] = items[i+1];
+            for (var i = 0; i < items.length; i += 2) {
+                obj[items[i]] = items[i + 1];
+            }
+
+            this.push(new batavia.core.Dict(obj));
+
+            return;
+
+        case batavia.BATAVIA_MAGIC_34:
+            this.push(new batavia.core.Dict());
+
+            return;
+
+        default:
+            throw new batavia.core.BataviaError(
+                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python versionStrange"
+            );
     }
+};
 
-    this.push(new batavia.core.Dict(obj));
+batavia.VirtualMachine.prototype.byte_STORE_MAP = function() {
+    switch (batavia.BATAVIA_MAGIC) {
+        case batavia.BATAVIA_MAGIC_35:
+            throw new batavia.core.BataviaError(
+                "STORE_MAP is unsupported with BATAVIA_MAGIC"
+            );
+
+        case batavia.BATAVIA_MAGIC_34:
+            var items = this.popn(3);
+            items[0][items[2]] = items[1];
+            this.push(items[0]);
+
+            return;
+
+        default:
+            throw new batavia.core.BataviaError(
+                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python versionStrange"
+            );
+    }
 };
 
 batavia.VirtualMachine.prototype.byte_UNPACK_SEQUENCE = function(count) {

--- a/batavia/batavia.js
+++ b/batavia/batavia.js
@@ -11,3 +11,7 @@ var batavia = {
     builtins: {}
 };
 
+// set in PYCFile while parsing python bytecode
+batavia.BATAVIA_MAGIC = null;
+batavia.BATAVIA_MAGIC_34 = String.fromCharCode(238, 12, 13, 10);
+batavia.BATAVIA_MAGIC_35 = String.fromCharCode(22, 13, 13, 10);

--- a/batavia/core/PYCFile.js
+++ b/batavia/core/PYCFile.js
@@ -9,6 +9,8 @@ batavia.core.PYCFile = function(data) {
     this.size = data.slice(8, 12);
     this.data = data.slice(12);
 
+    batavia.BATAVIA_MAGIC = this.magic;
+
     // this.data = data;
     this.depth = 0;
     this.ptr = 0;


### PR DESCRIPTION
The deal has to do with that fact that byte code has slightly changed in Python3.5. This change attempts to add support for batavia for both Py3.4 and Py3.5 by storing the byte code magic number in a window global hence allowing to check for it in the runloop.

The PR is related to https://github.com/pybee/batavia/issues/26 as well as https://github.com/pybee/batavia/issues/41.
