### PR TITLE
In-place string additions

### DIFF
--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -221,15 +221,16 @@ String.prototype.__itruediv__ = function(other) {
 };
 
 String.prototype.__iadd__ = function(other) {
-    if (other !== null) {
-        if (batavia.isinstance(other, [
+    if (other == null || other == batavia.types.NoneType){
+        throw new batavia.builtins.TypeError("Can't convert 'NoneType' object to str implicitly");
+    } else if(batavia.isinstance(other, [
                     batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, 
                     batavia.types.Float, batavia.types.Int, batavia.types.List,
                 ])) {
-            throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
-        } else {
-            throw new batavia.builtins.NotImplementedError("String.__iadd__ has not been implemented");
-        }
+        throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
+
+    } else {
+        throw new batavia.builtins.NotImplementedError("String.__iadd__ has not been implemented");
     }
 };
 

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -223,7 +223,7 @@ String.prototype.__itruediv__ = function(other) {
 String.prototype.__iadd__ = function(other) {
     if (other !== null) {
         if (batavia.isinstance(other, [
-                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict,
+                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, batavia.types.Float,
                 ])) {
             throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
         } else {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -223,7 +223,7 @@ String.prototype.__itruediv__ = function(other) {
 String.prototype.__iadd__ = function(other) {
     if (other !== null) {
         if (batavia.isinstance(other, [
-                    batavia.types.Bool, batavia.types.Tuple,
+                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict,
                 ])) {
             throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
         } else {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -223,7 +223,7 @@ String.prototype.__itruediv__ = function(other) {
 String.prototype.__iadd__ = function(other) {
     if (other !== null) {
         if (batavia.isinstance(other, [
-                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, batavia.types.Float,
+                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, batavia.types.Float, batavia.types.Int,
                 ])) {
             throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
         } else {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -223,7 +223,8 @@ String.prototype.__itruediv__ = function(other) {
 String.prototype.__iadd__ = function(other) {
     if (other !== null) {
         if (batavia.isinstance(other, [
-                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, batavia.types.Float, batavia.types.Int,
+                    batavia.types.Bool, batavia.types.Tuple, batavia.types.Dict, 
+                    batavia.types.Float, batavia.types.Int, batavia.types.List,
                 ])) {
             throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
         } else {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -223,9 +223,9 @@ String.prototype.__itruediv__ = function(other) {
 String.prototype.__iadd__ = function(other) {
     if (other !== null) {
         if (batavia.isinstance(other, [
-                    batavia.types.Bool
+                    batavia.types.Bool, batavia.types.Tuple,
                 ])) {
-            throw new batavia.builtins.TypeError("Can't convert 'bool' object to str implicitly");
+            throw new batavia.builtins.TypeError("Can't convert '" + batavia.type_name(other) + "' object to str implicitly");
         } else {
             throw new batavia.builtins.NotImplementedError("String.__iadd__ has not been implemented");
         }

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -305,7 +305,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_bytes',
         'test_add_class',
         'test_add_complex',
-        'test_add_float',
         'test_add_frozenset',
         'test_add_int',
         'test_add_list',

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -306,7 +306,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_class',
         'test_add_complex',
         'test_add_frozenset',
-        'test_add_int',
         'test_add_list',
         'test_add_none',
         'test_add_set',

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -306,7 +306,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_class',
         'test_add_complex',
         'test_add_frozenset',
-        'test_add_list',
         'test_add_none',
         'test_add_set',
         'test_add_str',

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -306,7 +306,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_class',
         'test_add_complex',
         'test_add_frozenset',
-        'test_add_none',
         'test_add_set',
         'test_add_str',
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -305,7 +305,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_bytes',
         'test_add_class',
         'test_add_complex',
-        'test_add_dict',
         'test_add_float',
         'test_add_frozenset',
         'test_add_int',

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -313,7 +313,6 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_add_none',
         'test_add_set',
         'test_add_str',
-        'test_add_tuple',
 
         'test_and_bool',
         'test_and_bytearray',


### PR DESCRIPTION
In place additions to strings now throw the correct errors for the following types:
list, int, float, dict, tuple, NoneType