### PR TITLE
Remove `__idiv__` placeholders from type definitions.

### DIFF
--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -277,10 +277,6 @@ Boolean.prototype.__or__ = function(other) {
  * Inplace operators
  **************************************************/
 
-Boolean.prototype.__idiv__ = function(other) {
-    throw new batavia.builtins.AttributeError("module' object has no attribute 'idiv'");
-};
-
 Boolean.prototype.__ifloordiv__ = function(other) {
     throw new batavia.builtins.NotImplementedError("Boolean.__ifloordiv__ has not been implemented");
 };

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -192,10 +192,6 @@ batavia.types.Bytes = function() {
      * Inplace operators
      **************************************************/
 
-    Bytes.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Bytes.__idiv__ has not been implemented");
-    };
-
     Bytes.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Bytes.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -169,10 +169,6 @@ batavia.types.Complex = function() {
      * Inplace operators
      **************************************************/
 
-    Complex.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Complex.__idiv__ has not been implemented");
-    };
-
     Complex.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Complex.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -222,10 +222,6 @@ batavia.types.Dict = function() {
      * Inplace operators
      **************************************************/
 
-    Dict.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Dict.__idiv__ has not been implemented");
-    };
-
     Dict.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Dict.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -274,10 +274,6 @@ batavia.types.Float = function() {
      * Inplace operators
      **************************************************/
 
-    Float.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Float.__idiv__ has not been implemented");
-    };
-
     Float.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Float.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -319,10 +319,6 @@ batavia.types.Int = function() {
      * Inplace operators
      **************************************************/
 
-    Int.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Int.__idiv__ has not been implemented");
-    };
-
     Int.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Int.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -234,10 +234,6 @@ batavia.types.List = function() {
      * Inplace operators
      **************************************************/
 
-    List.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("List.__idiv__ has not been implemented");
-    };
-
     List.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("List.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/NoneType.js
+++ b/batavia/types/NoneType.js
@@ -134,10 +134,6 @@ batavia.types.NoneType = {
      * Inplace operators
      **************************************************/
 
-    __idiv__: function(other) {
-        throw new batavia.builtins.NotImplementedError("NoneType.__idiv__ has not been implemented");
-    },
-
     __ifloordiv__: function(other) {
         throw new batavia.builtins.NotImplementedError("NoneType.__ifloordiv__ has not been implemented");
     },

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -169,10 +169,6 @@ batavia.types.Set = function() {
      * Inplace operators
      **************************************************/
 
-    Set.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Set.__idiv__ has not been implemented");
-    };
-
     Set.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Set.__ifloordiv__ has not been implemented");
     };

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -266,10 +266,6 @@ String.prototype.__or__ = function(other) {
  * Inplace operators
  **************************************************/
 
-String.prototype.__idiv__ = function(other) {
-    throw new batavia.builtins.NotImplementedError("String.__idiv__ has not been implemented");
-};
-
 String.prototype.__ifloordiv__ = function(other) {
     throw new batavia.builtins.NotImplementedError("String.__ifloordiv__ has not been implemented");
 };

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -184,10 +184,6 @@ batavia.types.Tuple = function() {
      * Inplace operators
      **************************************************/
 
-    Tuple.prototype.__idiv__ = function(other) {
-        throw new batavia.builtins.NotImplementedError("Tuple.__idiv__ has not been implemented");
-    };
-
     Tuple.prototype.__ifloordiv__ = function(other) {
         throw new batavia.builtins.NotImplementedError("Tuple.__ifloordiv__ has not been implemented");
     };


### PR DESCRIPTION
`__idiv__` does not exist in python3.
https://docs.python.org/3/library/operator.html