### PR TITLE
Add `bower.json` file that controls Bower installation.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "batavia",
+  "main": [
+	"batavia/batavia.js"
+  ],
+  "homepage": "https://github.com/pybee/batavia",
+  "authors": [
+    "Russell Keith-Magee <russell@keith-magee.com>"
+  ],
+  "description": "Run Python bytecode in Javascript",
+  "keywords": [
+    "python"
+  ],
+  "license": "New BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+	"testserver",
+	".gitignore",
+	".travis.yml",
+	"AUTHORS",
+	"CONTRIBUTING.md",
+	"LICENSE",
+	"MANIFEST.in",
+	"Makefile",
+	"README.rst",
+	"batavia.egg-info",
+	"docs",
+	"setup.py"
+  ]
+}


### PR DESCRIPTION
`bower install batavia` (once Batavia is registered) will
result in a `bower_components/batavia/batavia/batavia.js`
being available for use along with all other Javascript files.

Addresses #32

Signed-off-by: Kenneth Love <kennethlove@gmail.com>