### PR TITLE
Implement time.time() and time.sleep(), with tests.

### DIFF
--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -2,5 +2,23 @@
 batavia.modules.time = {
     clock: function() {
         return new Date().getTime();
+    },
+
+    time: function() {
+        // JS operates in milliseconds, Python in seconds, so divide by 1000
+        return new Date().getTime() / 1000;
+    },
+
+    sleep: function(secs) {
+        if (secs < 0) {
+            throw new batavia.builtins.ValueError('sleep length must be non-negative')
+        }
+
+        var start = new Date().getTime();
+        while (1) {
+            if ((new Date().getTime() - start) / 1000 > secs){
+                break;
+            }
+        }
     }
 };

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -6,7 +6,7 @@ batavia.modules.time = {
 
     time: function() {
         // JS operates in milliseconds, Python in seconds, so divide by 1000
-        return new Date().getTime() / 1000;
+        return new batavia.types.Float(new Date().getTime() / 1000);
     },
 
     sleep: function(secs) {

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -1,0 +1,31 @@
+from ..utils import TranspileTestCase
+
+import unittest
+
+
+class TimeTests(TranspileTestCase):
+    @unittest.expectedFailure
+    def test_time(self):
+        # CONSIDER: Is there a good way to test this? CPython sorta punts it...
+        self.assertCodeExecution("""
+            import time
+            print(time.time())
+            print('Done.')
+            """)
+
+    def test_sleep(self):
+        self.assertCodeExecution("""
+            import time
+            time.sleep(.1)
+            print('Done.')
+            """)
+
+    def test_sleep_negative(self):
+        self.assertCodeExecution("""
+            import time
+            try:
+                time.sleep(-1)
+            except ValueError as err:
+                print(err)
+            print('Done.')
+            """)

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -6,10 +6,15 @@ import unittest
 class TimeTests(TranspileTestCase):
     @unittest.expectedFailure
     def test_time(self):
-        # CONSIDER: Is there a good way to test this? CPython sorta punts it...
         self.assertCodeExecution("""
             import time
-            print(time.time())
+
+            # Demonstrate that we're getting the same type...
+            print(type(time.time()))
+
+            # ...and that type is infact a float.
+            print(isinstance(time.time(), float))
+
             print('Done.')
             """)
 

--- a/tests/structures/test_import.py
+++ b/tests/structures/test_import.py
@@ -4,7 +4,6 @@ import unittest
 
 
 class ImportTests(TranspileTestCase):
-    @unittest.expectedFailure
     def test_import_stdlib_module(self):
         "You can import a Python module implemented in Java (a native stdlib shim)"
         self.assertCodeExecution(


### PR DESCRIPTION
As noted in the title, this PR implements `time.time()` and `time.sleep()`.

The test for `time.time()` is currently marked as an expected failure because ... how do you test it? You can't compare the return value because every subsequent call returns a different value. You may be able to mock it out, but you'd have to do this in both JS and Python.

CPython seems to sort of punt it, but I'm not entirely sure how that test[0] is supposed to work. In any case, `time.get_clock_info()` isn't implemented in batavia, soooo...

[0] https://github.com/python/cpython/blob/master/Lib/test/test_time.py#L60