### PR TITLE
Typo

### DIFF
--- a/docs/intro/getting-started.rst
+++ b/docs/intro/getting-started.rst
@@ -27,7 +27,7 @@ Then create a virtual environment and install Batavia into it:
     
 .. code-block:: doscom
     > virtualenv --python=c:\python34\python.exe env
-    > cd env\Spripts
+    > cd env\Scripts
     > activate
     > pip install -e .
     


### PR DESCRIPTION
Very minor typo.  On a related note, the code-block:: doscom doesn't seem to show up anywhere - not in the github version of these docs or the hosted readthedocs.  Similarly, the code block for anaconda doesn't appear (the page says For those using anaconda: and then there's nothing).  I don't quite know how to fix that