### PR TITLE
Implement builtin 'reversed' to return a reversed iterable

### DIFF
--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -870,7 +870,7 @@ batavia.builtins.reversed = function(args, kwargs) {
     if (batavia.isinstance(iterable, [batavia.types.List, batavia.types.Tuple])) {
         var new_iterable = iterable.slice(0);
         new_iterable.reverse();
-        return new_iterable;
+        return new batavia.types.List(new_iterable);
     }
 
     throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'reversed' not implemented for objects");

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -865,9 +865,20 @@ batavia.builtins.repr = function(args, kwargs) {
 };
 batavia.builtins.repr.__doc__ = 'repr(object) -> string\n\nReturn the canonical string representation of the object.\nFor most object types, eval(repr(object)) == object.';
 
-batavia.builtins.reversed = function() {
-    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'reversed' not implemented");
+batavia.builtins.reversed = function(args, kwargs) {
+    var iterable = args[0];
+    if (batavia.isinstance(iterable, [batavia.types.List, batavia.types.Tuple])) {
+        var new_iterable = iterable.slice(0);
+        new_iterable.reverse();
+        return new_iterable;
+    }
+
+    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'sorted' not implemented for objects");
+
 };
+
+batavia.builtins.reversed.__doc__ = 'reversed(sequence) -> reverse iterator over values of the sequence\n\nReturn a reverse iterator';
+
 
 batavia.builtins.round = function(args) {
     var p = 0; // Precision

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -873,7 +873,7 @@ batavia.builtins.reversed = function(args, kwargs) {
         return new_iterable;
     }
 
-    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'sorted' not implemented for objects");
+    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'reversed' not implemented for objects");
 
 };
 

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -2,7 +2,11 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class ReversedTests(TranspileTestCase):
-    pass
+    
+    def test_reverse_list(self):
+        self.assertCodeExecution("""
+            list(reversed([1,2,3]))
+        """)
 
 
 class BuiltinReversedFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -5,7 +5,7 @@ class ReversedTests(TranspileTestCase):
     
     def test_reverse_list(self):
         self.assertCodeExecution("""
-            list(reversed([1,2,3]))
+            print(list(reversed([1,2,3])))
         """)
 
 


### PR DESCRIPTION
I understand this isn't 100% analogous to the behavior of reversed in Python 3.4, but I didn't see an existing concept of generators yet. 