### PR TITLE
Add support for bool conversion to more types

### DIFF
--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -28,7 +28,7 @@ batavia.types.Bytes = function() {
      **************************************************/
 
     Bytes.prototype.__bool__ = function() {
-        return this.size() !== 0;
+        return this.val.length > 0;
     };
 
     Bytes.prototype.__repr__ = function() {

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -100,7 +100,7 @@ batavia.types.Complex = function() {
      **************************************************/
 
     Complex.prototype.__bool__ = function() {
-        return this.real || this.imag;
+        return Boolean(this.real || this.imag);
     };
 
     Complex.prototype.__iter__ = function() {

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -26,7 +26,7 @@ batavia.types.Dict = function() {
      **************************************************/
 
     Dict.prototype.__bool__ = function() {
-        return this.size() !== 0;
+        return Object.keys(this).length > 0;
     };
 
     Dict.prototype.__repr__ = function() {

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -52,6 +52,10 @@ batavia.types.List = function() {
             }).join(', ') + ']';
     };
 
+    List.prototype.__bool__ = function() {
+        return this.length > 0;
+    };
+
     /**************************************************
      * Comparison operators
      **************************************************/

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -27,7 +27,7 @@ batavia.types.Set = function() {
      **************************************************/
 
     Set.prototype.__bool__ = function() {
-        return this.valueOf().length !== 0;
+        return Object.keys(this).length > 0;
     };
 
     Set.prototype.__iter__ = function() {

--- a/tests/builtins/test_bool.py
+++ b/tests/builtins/test_bool.py
@@ -54,14 +54,8 @@ class BuiltinBoolFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["bool"]
 
     not_implemented = [
-        'test_bytes',
         'test_bytearray',
         'test_class',
-        'test_complex',
-        'test_class',
-        'test_dict',
         'test_frozenset',
-        'test_list',
         'test_range',
-        'test_set',
     ]


### PR DESCRIPTION
Implement the `__bool__` method for bytes, complex, dict, list and set types so these types can be converted by the bool builtin.