### PR TITLE
We don't need to install phantomjs ourselves on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,16 +2,6 @@ machine:
   python:
     version: 3.5.1
 
-dependencies:
-  cache_directories:
-    - circleci-phantomjs
-  pre:
-     - pip install .
-     - mkdir -p circleci-phantomjs
-     - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2 -O circleci-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2
-     - tar -xvf $PWD/circleci-phantomjs/phantomjs-2.0.0-ubuntu-14.04.tar.bz2 -C circleci-phantomjs
-
 test:
   override:
-     - phantomjs --version
      - python setup.py test


### PR DESCRIPTION
Should save a few seconds per test, and won't need to download from S3. :)