### PR TITLE
import this requires dict.get, str.join to be implemented

### DIFF
--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -272,6 +272,16 @@ batavia.types.Dict = function() {
      * Methods
      **************************************************/
 
+    Dict.prototype.get = function(key, backup) {
+        if (this.__contains__(key)) {
+            return this[key];
+        } else if (typeof backup === 'undefined') {
+            return null;
+        } else {
+            return backup;
+        }
+    };
+
     Dict.prototype.update = function(values) {
         for (var key in values) {
             if (values.hasOwnProperty(key)) {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -15,7 +15,28 @@ String.prototype.__iter__ = function() {
 };
 
 String.prototype.__repr__ = function() {
-    return "'" + this.toString() + "'";
+    // we have to replace all non-printable characters
+    return "'" + this.toString()
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'")
+        .replace(/\x7F/g, "\\x7f")
+        .replace(/[\u0000-\u001F]/g, function (match) {
+            var code = match.charCodeAt(0);
+            switch (code) {
+            case 9:
+                return "\\t";
+            case 10:
+                return "\\n";
+            case 13:
+                return "\\r";
+            default:
+                var hex = code.toString(16);
+                if (hex.length == 1) {
+                  hex = "0" + hex;
+                }
+                return "\\x" + hex;
+            }
+        }) + "'";
 };
 
 String.prototype.__str__ = function() {
@@ -387,6 +408,20 @@ String.prototype.__ixor__ = function(other) {
 String.prototype.__ior__ = function(other) {
     throw new batavia.builtins.TypeError("unsupported operand type(s) for |=: 'str' and '" + batavia.type_name(other) + "'");
 
+};
+
+/**************************************************
+ * Methods
+ **************************************************/
+
+String.prototype.join = function(iter) {
+    var l = new batavia.types.List(iter);
+    for (var i = 0; i < l.length; i++) {
+        if (!batavia.isinstance(l[i], batavia.types.Str)) {
+            throw new batavia.builtins.TypeError("sequence item " + i + ": expected str instance, " + batavia.type_name(l[i]) + " found");
+        }
+    }
+    return l.join(this);
 };
 
 /**************************************************

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -2,7 +2,15 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class ReprTests(TranspileTestCase):
-    pass
+    def test_hovercraft_full_of_eels(self):
+        self.assertCodeExecution("""
+            print(repr("Mÿ hôvèrçràft îß fûłl öf éêlś"))
+            """)
+
+    def test_repr_escape(self):
+        self.assertCodeExecution("""
+            print(repr("".join(chr(x) for x in range(128))))
+            """)
 
 
 class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_str.py
+++ b/tests/builtins/test_str.py
@@ -4,7 +4,6 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 class StrTests(TranspileTestCase):
     pass
 
-
 class BuiltinStrFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["str"]
 

--- a/tests/structures/test_list_comprehension.py
+++ b/tests/structures/test_list_comprehension.py
@@ -17,3 +17,40 @@ class ListComprehensionTests(TranspileTestCase):
             print(list(v**2 for v in x))
             print('Done.')
             """)
+
+    # copy of this.py -- a nice exercise of list comprehensions
+    def test_import_this(self):
+        self.assertCodeExecution('''
+            s = """Gur Mra bs Clguba, ol Gvz Crgref
+
+            Ornhgvshy vf orggre guna htyl.
+            Rkcyvpvg vf orggre guna vzcyvpvg.
+            Fvzcyr vf orggre guna pbzcyrk.
+            Pbzcyrk vf orggre guna pbzcyvpngrq.
+            Syng vf orggre guna arfgrq.
+            Fcnefr vf orggre guna qrafr.
+            Ernqnovyvgl pbhagf.
+            Fcrpvny pnfrf nera'g fcrpvny rabhtu gb oernx gur ehyrf.
+            Nygubhtu cenpgvpnyvgl orngf chevgl.
+            Reebef fubhyq arire cnff fvyragyl.
+            Hayrff rkcyvpvgyl fvyraprq.
+            Va gur snpr bs nzovthvgl, ershfr gur grzcgngvba gb thrff.
+            Gurer fubhyq or bar-- naq cersrenoyl bayl bar --boivbhf jnl gb qb vg.
+            Nygubhtu gung jnl znl abg or boivbhf ng svefg hayrff lbh'er Qhgpu.
+            Abj vf orggre guna arire.
+            Nygubhtu arire vf bsgra orggre guna *evtug* abj.
+            Vs gur vzcyrzragngvba vf uneq gb rkcynva, vg'f n onq vqrn.
+            Vs gur vzcyrzragngvba vf rnfl gb rkcynva, vg znl or n tbbq vqrn.
+            Anzrfcnprf ner bar ubaxvat terng vqrn -- yrg'f qb zber bs gubfr!"""
+
+            d = {}
+            for c in (65, 97):
+                for i in range(26):
+                    d[chr(i+c)] = chr((i+13) % 26 + c)
+
+            print("".join([d.get(c, c) for c in s]))
+            ''',
+            substitutions={
+                # workaround for PhantomJS producing extra new lines which we have to squash
+                "Peters\n\nBeautiful": ["Peters\nBeautiful",]
+            })


### PR DESCRIPTION
I was working on getting the `this` module to work, but noticed these missing methods.

(There is a scoping bug that prevents the `this` module from being imported that I am working on separately.)