### PR TITLE
Stub out _weakref, add in abc and _weakrefset stdlib modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ BASE_FILES_WIN=\
 
 EXTRA_FILES=\
 		batavia/modules/misc.js \
+		batavia/modules/stdlib/_weakrefset.js \
+		batavia/modules/stdlib/abc.js \
 		batavia/modules/stdlib/bisect.js \
 		batavia/modules/stdlib/colorsys.js \
 		batavia/modules/stdlib/copyreg.js \
@@ -100,6 +102,8 @@ EXTRA_FILES=\
 
 EXTRA_FILES_WIN=\
 		batavia\modules\misc.js \
+		batavia\modules\stdlib\_weakrefset.js \
+		batavia\modules\stdlib\abc.js \
 		batavia\modules\stdlib\bisect.js \
 		batavia\modules\stdlib\colorsys.js \
 		batavia\modules\stdlib\copyreg.js \

--- a/batavia/modules/misc.js
+++ b/batavia/modules/misc.js
@@ -2,3 +2,29 @@
 batavia.modules._operator = {
     __doc__: "Operator interface.\n\nThis module exports a set of functions corresponding\nto the intrinsic operators of Python.  For example, operator.add(x, y)\nis equivalent to the expression x+y.  The function names are those\nused for special methods; variants without leading and trailing\n'__' are also provided for convenience."
 };
+
+// stub "implementation" of _weakref
+// JS doesn't quite support weak references, though
+// in the future we might be able to use WeakMap or WeakSet to hack it.
+batavia.modules._weakref = {
+    CallableProxyType: null, // not used directly in stdlib
+
+    ProxyType: null, // not used directly in stdlib
+
+    ReferenceType: null, // not used directly in stdlib
+
+    getweakrefs: function(object) {
+        return [];
+    },
+    getweakrefcount: function(object) {
+        return 0;
+    },
+    proxy: function(object, callback) {
+        // TODO: support the finalize callback
+        return object;
+    },
+    ref: function(object) {
+      return object;
+    },
+    __doc__: ""
+};

--- a/compile_stdlib.py
+++ b/compile_stdlib.py
@@ -15,6 +15,8 @@ import sys
 import tempfile
 
 enabled_modules = [
+    '_weakrefset',
+    'abc',
     'bisect',
     'colorsys',
     'copyreg',

--- a/tests/modules/test_stdlib.py
+++ b/tests/modules/test_stdlib.py
@@ -12,6 +12,9 @@ def test_module(self, name):
         """ % (name, name), run_in_function=False)
 
 class StdlibTests(TranspileTestCase):
+    def test__weakref(self):
+        test_module(self, "_weakref")
+
     def test_bisect(self):
         test_module(self, "bisect")
 

--- a/tests/modules/test_stdlib.py
+++ b/tests/modules/test_stdlib.py
@@ -5,15 +5,21 @@ import unittest
 # do basic tests for now
 # TODO: execute complete tests for each stdlib module
 
-def test_module(self, name):
+def test_module(self, name, exclude=[]):
     self.assertCodeExecution("""
         import %s
-        print(sorted([x for x in list(dir(%s)) if not x.startswith('_')]))
-        """ % (name, name), run_in_function=False)
+        print(sorted([x for x in list(dir(%s)) if not x.startswith('_') and x not in set(%s)]))
+        """ % (name, name, repr(exclude)), run_in_function=False)
 
 class StdlibTests(TranspileTestCase):
     def test__weakref(self):
         test_module(self, "_weakref")
+
+    def test__weakrefset(self):
+        test_module(self, "_weakrefset")
+
+    def test_abc(self):
+        test_module(self, "abc", exclude=['ref'])
 
     def test_bisect(self):
         test_module(self, "bisect")

--- a/testserver/testbed.html
+++ b/testserver/testbed.html
@@ -78,6 +78,8 @@
     <script src="/static/batavia/modules/sys.js"></script>
     <script src="/static/batavia/modules/time.js"></script>
     <script src="/static/batavia/modules/misc.js"></script>
+    <script src="/static/batavia/modules/stdlib/_weakrefset.js"></script>
+    <script src="/static/batavia/modules/stdlib/abc.js"></script>
     <script src="/static/batavia/modules/stdlib/bisect.js"></script>
     <script src="/static/batavia/modules/stdlib/colorsys.js"></script>
     <script src="/static/batavia/modules/stdlib/copyreg.js"></script>


### PR DESCRIPTION
These are three key modules in the standard library that others depend on.

Currently, it is not possible to implement `_weakref` in a reasonable manner in JS, so we stub it out for now. In the future, we might be able to do better with WeakSet (or, less likely, WeakMap), but they aren't well-supported yet.