### PR TITLE
Implement globals(), add token stdlib module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ EXTRA_FILES=\
 		batavia/modules/stdlib/bisect.js \
 		batavia/modules/stdlib/colorsys.js \
 		batavia/modules/stdlib/copyreg.js \
+		batavia/modules/stdlib/token.js \
 		batavia/modules/stdlib/operator.js \
 		batavia/modules/stdlib/stat.js \
 		batavia/modules/stdlib/this.js
@@ -107,6 +108,7 @@ EXTRA_FILES_WIN=\
 		batavia\modules\stdlib\bisect.js \
 		batavia\modules\stdlib\colorsys.js \
 		batavia\modules\stdlib\copyreg.js \
+		batavia\modules\stdlib\token.js \
 		batavia\modules\stdlib\operator.js \
 		batavia\modules\stdlib\stat.js \
 		batavia\modules\stdlib\this.js

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -50,6 +50,7 @@ batavia.builtins.__import__ = function(args, kwargs) {
         if (payload) {
             var code = batavia.modules.marshal.load_pyc(this, payload);
             // Convert code object to module
+            args[1].__name__ = args[0]
             var frame = this.make_frame({
                 'code': code,
                 'f_globals': args[1]

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -641,8 +641,35 @@ batavia.builtins.getattr = function(args) {
 };
 batavia.builtins.getattr.__doc__ = "getattr(object, name[, default]) -> value\n\nGet a named attribute from an object; getattr(x, 'y') is equivalent to x.y.\nWhen a default argument is given, it is returned when the attribute doesn't\nexist; without it, an exception is raised in that case.";
 
-batavia.builtins.globals = function() {
-    throw new batavia.builtins.NotImplementedError("Builtin Batavia function 'globals' not implemented");
+// TODO: this should be a proper dictionary
+batavia.builtins.globals = function(args, kwargs) {
+    if (arguments.length != 2) {
+        throw new batavia.builtins.BataviaError('Batavia calling convention not used.');
+    }
+    if (kwargs && Object.keys(kwargs).length > 0) {
+        throw new batavia.builtins.TypeError("globals() doesn't accept keyword arguments");
+    }
+    if (args && args.length != 0) {
+        throw new batavia.builtins.TypeError('globals() takes no arguments (' + args.length + ' given)');
+    }
+    var globals = this.frame.f_globals;
+
+    // support items() iterator
+    globals.items = function() {
+        var l = [];
+        var keys = Object.keys(globals);
+        for (var i in keys) {
+            var k = keys[i];
+            // workaround until we have a proper dictionary
+            if (k == 'items') {
+              continue;
+            }
+            l.push(new batavia.types.Tuple([k, globals[k]]));
+        }
+        l = new batavia.types.List(l);
+        return l;
+    };
+    return globals;
 };
 batavia.builtins.globals.__doc__ = "globals() -> dictionary\n\nReturn the dictionary containing the current scope's global variables.";
 

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -301,7 +301,27 @@ batavia.types.Dict = function() {
                 result.push([key, this[key]]);
             }
         }
-        return result;
+        return new batavia.types.List(result);
+    };
+
+    Dict.prototype.keys = function() {
+        var result = [];
+        for (var key in this) {
+            if (this.hasOwnProperty(key)) {
+                result.push(key);
+            }
+        }
+        return new batavia.types.List(result);
+    };
+
+    Dict.prototype.values = function() {
+        var result = [];
+        for (var key in this) {
+            if (this.hasOwnProperty(key)) {
+                result.push(this[key]);
+            }
+        }
+        return new batavia.types.List(result);
     };
 
     return Dict;

--- a/compile_stdlib.py
+++ b/compile_stdlib.py
@@ -20,6 +20,7 @@ enabled_modules = [
     'bisect',
     'colorsys',
     'copyreg',
+    'token',
     'operator',
     'stat',
     'this',

--- a/tests/builtins/test_globals.py
+++ b/tests/builtins/test_globals.py
@@ -2,28 +2,16 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class GlobalsTests(TranspileTestCase):
-    pass
+    def test_globals(self):
+        self.assertCodeExecution("""
+            # make sure we can get and modify globals
+            print('x' not in globals())
+            globals()['x'] = 1
+            print('x' in globals())
+            print(globals()['x'])
+            print(x)
+            """)
 
 
 class BuiltinGlobalsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["globals"]
-
-    not_implemented = [
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
-    ]

--- a/tests/modules/test_stdlib.py
+++ b/tests/modules/test_stdlib.py
@@ -30,6 +30,13 @@ class StdlibTests(TranspileTestCase):
     def test_copyreg(self):
         test_module(self, "copyreg")
 
+    def test_token(self):
+        # our version doesn't quite sync up
+        self.assertCodeExecution("""
+            import token
+            print("Done")
+            """)
+
     def test_operator(self):
         # there is a bunch of extra stuff in this in the native Python 3.5 module
         self.assertCodeExecution("""

--- a/testserver/testbed.html
+++ b/testserver/testbed.html
@@ -83,6 +83,7 @@
     <script src="/static/batavia/modules/stdlib/bisect.js"></script>
     <script src="/static/batavia/modules/stdlib/colorsys.js"></script>
     <script src="/static/batavia/modules/stdlib/copyreg.js"></script>
+    <script src="/static/batavia/modules/stdlib/token.js"></script>
     <script src="/static/batavia/modules/stdlib/operator.js"></script>
     <script src="/static/batavia/modules/stdlib/stat.js"></script>
     <script src="/static/batavia/modules/stdlib/this.js"></script>


### PR DESCRIPTION
Also implement `dict.keys()` and `dict.values()` and pass `__name__` to stdlib modules, which is needed for the `token` module.