### PR TITLE
Implement dictionaries using our own hash table impementation

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1366,7 +1366,11 @@ batavia.VirtualMachine.prototype.byte_STORE_SUBSCR = function() {
 
 batavia.VirtualMachine.prototype.byte_DELETE_SUBSCR = function() {
     var items = this.popn(2);
-    items[1].__delitem__(items[0]);
+    if (items[1].__delitem__) {
+        items[1].__delitem__(items[0]);
+    } else {
+        delete items[1][items[0]];
+    }
 };
 
 batavia.VirtualMachine.prototype.byte_BUILD_TUPLE = function(count) {

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -502,7 +502,7 @@ batavia.VirtualMachine.prototype.run_method = function(tag, args, kwargs, f_loca
         var payload = this.loader(tag);
         var code = batavia.modules.marshal.load_pyc(this, payload);
 
-        var callargs = new batavia.types.Dict();
+        var callargs = new batavia.types.JSDict();
         for (var i = 0, l = args.length; i < l; i++) {
             callargs[code.co_varnames[i]] = args[i];
         }
@@ -623,9 +623,9 @@ batavia.VirtualMachine.prototype.make_frame = function(kwargs) {
         }
     } else if (this.frames.length > 0) {
         f_globals = this.frame.f_globals;
-        f_locals = new batavia.types.Dict();
+        f_locals = new batavia.types.JSDict();
     } else {
-        f_globals = f_locals = new batavia.types.Dict({
+        f_globals = f_locals = new batavia.types.JSDict({
             '__builtins__': batavia.builtins,
             '__name__': '__main__',
             '__doc__': null,
@@ -1187,13 +1187,13 @@ batavia.VirtualMachine.prototype.byte_COMPARE_OP = function(opnum) {
         } if (items[1].__contains__) {
             result = items[1].__contains__(items[0]);
         } else {
-            result = items[0] in items[1];
+            result = (items[0] in items[1]);
         }
     } else if (opnum === 7) {
         if (items[1] === null) {  // x not in None
-            result = !batavia.types.NoneType.__contains__(items[0]);
+            result = batavia.types.NoneType.__contains__(items[0]).__not__();
         } else if (items[1].__contains__) {
-            result = !items[1].__contains__(items[0]);
+            result = items[1].__contains__(items[0]).__not__();
         } else {
             result = !(items[0] in items[1]);
         }
@@ -1384,13 +1384,13 @@ batavia.VirtualMachine.prototype.byte_BUILD_MAP = function(size) {
     switch (batavia.BATAVIA_MAGIC) {
         case batavia.BATAVIA_MAGIC_35:
             var items = this.popn(size * 2);
-            var obj = {};
+            var dict = new batavia.types.Dict();
 
             for (var i = 0; i < items.length; i += 2) {
-                obj[items[i]] = items[i + 1];
+                dict.__setitem__(items[i], items[i + 1]);
             }
 
-            this.push(new batavia.types.Dict(obj));
+            this.push(dict);
 
             return;
 
@@ -1417,7 +1417,7 @@ batavia.VirtualMachine.prototype.byte_STORE_MAP = function() {
         case batavia.BATAVIA_MAGIC_35a0:
         case batavia.BATAVIA_MAGIC_34:
             var items = this.popn(3);
-            items[0][items[2]] = items[1];
+            items[0].__setitem__(items[2], items[1]);
             this.push(items[0]);
 
             return;
@@ -1775,7 +1775,7 @@ batavia.VirtualMachine.prototype.call_function = function(arg, args, kwargs) {
     //https://docs.python.org/3/library/dis.html#opcode-CALL_FUNCTION
     var lenKw = Math.floor(arg / 256);
     var lenPos = arg % 256;
-    var namedargs = new batavia.types.Dict();
+    var namedargs = new batavia.types.JSDict();
     for (var i = 0; i < lenKw; i++) {
         var items = this.popn(2);
         namedargs[items[0]] = items[1];

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1357,12 +1357,16 @@ batavia.VirtualMachine.prototype.byte_DELETE_ATTR = function(name) {
 
 batavia.VirtualMachine.prototype.byte_STORE_SUBSCR = function() {
     var items = this.popn(3);
-    items[1][items[2]] = items[0];
+    if (items[1].__setitem__) {
+        items[1].__setitem__(items[2], items[0]);
+    } else {
+        items[1][items[2]] = items[0];
+    }
 };
 
 batavia.VirtualMachine.prototype.byte_DELETE_SUBSCR = function() {
     var items = this.popn(2);
-    delete items[1][items[0]];
+    items[1].__delitem__(items[0]);
 };
 
 batavia.VirtualMachine.prototype.byte_BUILD_TUPLE = function(count) {
@@ -1417,7 +1421,11 @@ batavia.VirtualMachine.prototype.byte_STORE_MAP = function() {
         case batavia.BATAVIA_MAGIC_35a0:
         case batavia.BATAVIA_MAGIC_34:
             var items = this.popn(3);
-            items[0].__setitem__(items[2], items[1]);
+            if (items[0].__setitem__) {
+                items[0].__setitem__(items[2], items[1]);
+            } else {
+                items[0][items[2]] = items[1];
+            }
             this.push(items[0]);
 
             return;

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -471,7 +471,7 @@ batavia.builtins.dict = function(args, kwargs) {
         }
     } else {
         // iterate through array to find any errors
-        for (i = 0; i < args[0].length; i++) {
+        for (var i = 0; i < args[0].length; i++) {
             if (args[0][i].length !== 2) {
                 // single number or bool in an iterable throws different error
                 if (batavia.isinstance(args[0][i], [batavia.types.Bool, batavia.types.Int])) {
@@ -490,7 +490,7 @@ batavia.builtins.dict = function(args, kwargs) {
     // passing a list as argument
     if (args.length === 1) {
         var dict = new batavia.types.Dict();
-        for (i = 0; i < args[0].length; i++) {
+        for (var i = 0; i < args[0].length; i++) {
             var sub_array = args[0][i];
             if (sub_array.length === 2) {
                 dict.__setitem__(sub_array[0], sub_array[1]);
@@ -541,7 +541,7 @@ batavia.builtins.enumerate = function(args, kwargs) {
     }
     var result = [];
     var values = args[0];
-    for (i = 0; i < values.length; i++) {
+    for (var i = 0; i < values.length; i++) {
         result.push([i, values[i]]);
     }
     // FIXME this should return a generator, not list

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -616,6 +616,9 @@ batavia.builtins.frozenset = function(args, kwargs) {
     if (args && args.length > 1) {
         throw new batavia.builtins.TypeError("set expected at most 1 arguments, got " + args.length);
     }
+    if (!args || args.length == 0) {
+        return new batavia.types.FrozenSet();
+    }
     return new batavia.types.FrozenSet(args[0]);
 };
 batavia.builtins.frozenset.__doc__ = 'frozenset() -> empty frozenset object\nfrozenset(iterable) -> frozenset object\n\nBuild an immutable unordered collection of unique elements.';
@@ -853,7 +856,7 @@ batavia.builtins.license = function() {
 batavia.builtins.license.__doc__ = 'license()\n\nPrompt printing the license text, a list of contributors, and the copyright notice';
 
 batavia.builtins.list = function(args) {
-    if (args.length === 0) {
+    if (!args || args.length === 0) {
       return new batavia.types.List();
     }
     return new batavia.types.List(args[0]);
@@ -932,8 +935,8 @@ batavia.builtins.object = function() {
 batavia.builtins.object.__doc__ = "The most base type"; // Yes, that's the entire docstring.
 
 batavia.builtins.oct = function(args) {
-    if (args.length !== 1) {
-        throw new batavia.builtins.TypeError("oct() takes exactly one argument (" + args.length + " given)");
+    if (!args || args.length !== 1) {
+        throw new batavia.builtins.TypeError("oct() takes exactly one argument (" + (args ? args.length : 0) + " given)");
     }
     var value = args[0];
     if (batavia.isinstance(value, batavia.types.Int)) {
@@ -973,6 +976,9 @@ batavia.builtins.ord.__doc__ = 'ord(c) -> integer\n\nReturn the integer ordinal 
 
 batavia.builtins.pow = function(args) {
     var x, y, z;
+    if (!args) {
+      throw new batavia.builtins.TypeError("pow expected at least 2 arguments, got 0");
+    }
     if (args.length === 2) {
         x = args[0];
         y = args[1];
@@ -1092,6 +1098,9 @@ batavia.builtins.reversed.__doc__ = 'reversed(sequence) -> reverse iterator over
 
 batavia.builtins.round = function(args) {
     var p = 0; // Precision
+    if (!args) {
+      throw new batavia.builtins.TypeError("Required argument 'number' (pos 1) not found");
+    }
     if (args.length == 2) {
         p = args[1];
     }
@@ -1117,6 +1126,9 @@ batavia.builtins.set = function(args,kwargs) {
     }
     if (args && args.length > 1) {
         throw new batavia.builtins.TypeError("set expected at most 1 arguments, got " + args.length);
+    }
+    if (!args || args.length == 0) {
+        return new batavia.types.Set();
     }
     return new batavia.types.Set(args[0]);
 };

--- a/batavia/core/builtins.js
+++ b/batavia/core/builtins.js
@@ -78,7 +78,7 @@ batavia.builtins.__import__ = function(args, kwargs) {
                 frame = this.make_frame({
                     'code': code,
                     'f_globals': args[1],
-                    'f_locals': new batavia.types.Dict(),
+                    'f_locals': new batavia.types.JSDict(),
                 });
                 this.run_frame(frame);
 
@@ -99,7 +99,7 @@ batavia.builtins.__import__ = function(args, kwargs) {
                     frame = this.make_frame({
                         'code': code,
                         'f_globals': args[1],
-                        'f_locals': new batavia.types.Dict(),
+                        'f_locals': new batavia.types.JSDict(),
                     });
                     this.run_frame(frame);
 

--- a/batavia/modules/marshal.js
+++ b/batavia/modules/marshal.js
@@ -653,7 +653,7 @@ batavia.modules.marshal = {
         case batavia.modules.marshal.TYPE_SET:
         case batavia.modules.marshal.TYPE_FROZENSET:
             n = batavia.modules.marshal.read_int32(vm, p);
-            console.log.info('TYPE_FROZENSET ' + n);
+            // console.log.info('TYPE_FROZENSET ' + n);
             if (vm.PyErr_Occurred()) {
                 break;
             }

--- a/batavia/modules/math.js
+++ b/batavia/modules/math.js
@@ -412,7 +412,7 @@ batavia.modules.math = {
             var den = 1.0;
 
             var z = y - 1;
-            for (i = 0; i < 8; i++) {
+            for (var i = 0; i < 8; i++) {
                 num = (num + p[i]) * z;
                 den = den * z + q[i];
             }
@@ -426,7 +426,7 @@ batavia.modules.math = {
                 result /= (y - 1.0);
             } else {
                 // Use the identity gamma(z+n) = z*(z+1)* ... *(z+n-1)*gamma(z)
-                for (i = 0; i < n; i++) {
+                for (var i = 0; i < n; i++) {
                     result *= y++;
                 }
            }

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -71,7 +71,6 @@ batavia.types.Dict = function() {
             var h = hash.int32() & new_mask;
             while (!isEmpty(new_keys[h])) {
                 h = (h + 1) & new_mask;
-                return;
             }
             new_keys[h] = key;
             new_values[h] = value;
@@ -317,7 +316,7 @@ batavia.types.Dict = function() {
 
             h = (h + 1) & this.mask;
             if (h == (hash.int32() & this.mask)) {
-                // we have looped, we'll rehash
+                // we have looped, we'll rehash (should be impossible)
                 this._increase_size();
                 h = hash.int32() & this.mask;
             }
@@ -434,7 +433,7 @@ batavia.types.Dict = function() {
      **************************************************/
 
     Dict.prototype.get = function(key, backup) {
-        var i = this._find_index(other);
+        var i = this._find_index(key);
         if (i !== null) {
             return this.data_values[i];
         } else if (typeof backup === 'undefined') {
@@ -456,7 +455,7 @@ batavia.types.Dict = function() {
         batavia.iter_for_each(updates, function(val) {
             var pieces = new batavia.types.Tuple(val);
             if (pieces.length != 2) {
-                throw new batavia.builtins.ValueError("dictionary update sequence element #" + i + " has length " + piece.length + "; 2 is required");
+                throw new batavia.builtins.ValueError("dictionary update sequence element #" + i + " has length " + pieces.length + "; 2 is required");
             }
             var key = pieces[0];
             var value = pieces[1];

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -2,13 +2,523 @@
  * A Python dict type
  *************************************************************************/
 
+/*
+ * Implementation details: we use closed hashing, open addressing,
+ * with linear probing and a max load factor of 0.75.
+ */
+
 batavia.types.Dict = function() {
     function Dict(args, kwargs) {
-        batavia.types.JSDict.call(this, args, kwargs);
+        this.data_keys = [];
+        this.data_values = [];
+        this.size = 0;
+        this.mask = 0;
+
+        if (args) {
+            this.update(args);
+        }
     }
 
-    Dict.prototype = Object.create(batavia.types.JSDict.prototype);
     Dict.prototype.__class__ = new batavia.types.Type('dict');
+
+    var MAX_LOAD_FACTOR = 0.75;
+    var INITIAL_SIZE = 8; // after size 0
+
+    /**
+     * Sentinel keys for empty and deleted.
+     */
+    var EMPTY = {
+        __hash__: function() {
+            return new batavia.types.Int(0);
+        },
+        __eq__: function(other) {
+            return new batavia.types.Bool(this === other);
+        }
+    };
+
+    var DELETED = {
+        __hash__: function() {
+            return new batavia.types.Int(0);
+        },
+        __eq__: function(other) {
+            return new batavia.types.Bool(this === other);
+        }
+    };
+
+    Dict.prototype._increase_size = function() {
+        // increase the table size and rehash
+        if (this.data_keys.length == 0) {
+            this.mask = INITIAL_SIZE - 1;
+            this.data_keys = new Array(INITIAL_SIZE);
+            this.data_values = new Array(INITIAL_SIZE);
+
+            for (var i = 0; i < INITIAL_SIZE; i++) {
+                this.data_keys[i] = EMPTY;
+            }
+            return;
+        }
+
+        var new_keys = new Array(this.data_keys.length * 2);
+        var new_values = new Array(this.data_keys.length * 2);
+        var new_mask = this.data_keys.length * 2 - 1; // assumes power of two
+        for (var i = 0; i < new_keys.length; i++) {
+            new_keys[i] = EMPTY;
+        }
+        batavia.iter_for_each(batavia.builtins.iter([this.items()], null), function(val) {
+            var key = val[0];
+            var value = val[1];
+            var hash = batavia.builtins.hash([key], null);
+            var h = hash.int32() & new_mask;
+            while (!isEmpty(new_keys[h])) {
+                h = (h + 1) & new_mask;
+                return;
+            }
+            new_keys[h] = key;
+            new_values[h] = value;
+        });
+        this.data_keys = new_keys;
+        this.data_values = new_values;
+        this.mask = new_mask;
+    };
+
+    /**************************************************
+     * Javascript compatibility methods
+     **************************************************/
+
+    Dict.prototype.toString = function() {
+        return this.__str__();
+    };
+
+
+    /**************************************************
+     * Type conversions
+     **************************************************/
+
+    Dict.prototype.__bool__ = function() {
+        return this.size > 0;
+    };
+
+    Dict.prototype.__repr__ = function() {
+        return this.__str__();
+    };
+
+    var isDeleted = function(x) {
+      return x !== null &&
+          batavia.builtins.hash([x], null).__eq__(new batavia.types.Int(0)).valueOf() &&
+          x.__eq__(DELETED).valueOf();
+    };
+
+    var isEmpty = function(x) {
+        return x !== null &&
+            batavia.builtins.hash([x], null).__eq__(new batavia.types.Int(0)).valueOf() &&
+            x.__eq__(EMPTY).valueOf();
+    };
+
+
+    Dict.prototype.__str__ = function() {
+        var result = "{";
+        var strings = [];
+        for (var i = 0; i < this.data_keys.length; i++) {
+            // ignore deleted or empty
+            var key = this.data_keys[i];
+            if (isEmpty(key) || isDeleted(key)) {
+                continue;
+            }
+            strings.push(batavia.builtins.repr([key], null) + ": " + batavia.builtins.repr([this.data_values[i]], null));
+        }
+        result += strings.join(", ");
+        result += "}";
+        return result;
+    };
+
+    /**************************************************
+     * Comparison operators
+     **************************************************/
+
+    Dict.prototype.__lt__ = function(other) {
+         if (other !== null) {
+             if (batavia.isinstance(other, [
+                         batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
+                         batavia.types.Int, batavia.types.JSDict, batavia.types.List,
+                         batavia.types.NoneType, batavia.types.Str, batavia.types.Tuple
+                    ])) {
+                 throw new batavia.builtins.TypeError("unorderable types: dict() < " + batavia.type_name(other) + "()");
+             } else {
+                 return this.valueOf() < other.valueOf();
+             }
+         } else {
+             throw new batavia.builtins.TypeError("unorderable types: dict() < NoneType()");
+         }
+        return this.valueOf() < other;
+    };
+
+    Dict.prototype.__le__ = function(other) {
+         if (other !== null) {
+             if (batavia.isinstance(other, [
+                         batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
+                         batavia.types.Int, batavia.types.JSDict, batavia.types.List,
+                         batavia.types.NoneType, batavia.types.Str, batavia.types.Tuple
+                    ])) {
+                 throw new batavia.builtins.TypeError("unorderable types: dict() <= " + batavia.type_name(other) + "()");
+             } else {
+                 return this.valueOf() <= other.valueOf();
+             }
+         } else {
+             throw new batavia.builtins.TypeError("unorderable types: dict() <= NoneType()");
+         }
+    };
+
+    Dict.prototype.__eq__ = function(other) {
+        return this.valueOf() == other;
+    };
+
+    Dict.prototype.__ne__ = function(other) {
+        return this.valueOf() != other;
+    };
+
+    Dict.prototype.__gt__ = function(other) {
+         if (other !== null) {
+             if (batavia.isinstance(other, [
+                         batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
+                         batavia.types.Int, batavia.types.JSDict, batavia.types.List,
+                         batavia.types.NoneType, batavia.types.Set, batavia.types.Str,
+                         batavia.types.Tuple
+                    ])) {
+                 throw new batavia.builtins.TypeError("unorderable types: dict() > " + batavia.type_name(other) + "()");
+             } else {
+                 return this.valueOf() > other.valueOf();
+             }
+         } else {
+             throw new batavia.builtins.TypeError("unorderable types: dict() > NoneType()");
+         }
+    };
+
+    Dict.prototype.__ge__ = function(other) {
+         if (other !== null) {
+             if (batavia.isinstance(other, [
+                         batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
+                         batavia.types.Int, batavia.types.JSDict, batavia.types.List,
+                         batavia.types.NoneType, batavia.types.Str, batavia.types.Tuple
+                    ])) {
+                 throw new batavia.builtins.TypeError("unorderable types: dict() >= " + batavia.type_name(other) + "()");
+             } else {
+                 return this.valueOf() >= other.valueOf();
+             }
+         } else {
+             throw new batavia.builtins.TypeError("unorderable types: dict() >= NoneType()");
+         }
+    };
+
+    /**************************************************
+     * Unary operators
+     **************************************************/
+
+    Dict.prototype.__pos__ = function() {
+        throw new batavia.builtins.TypeError("bad operand type for unary +: 'dict'");
+    };
+
+    Dict.prototype.__neg__ = function() {
+        throw new batavia.builtins.TypeError("bad operand type for unary -: 'dict'");
+    };
+
+    Dict.prototype.__not__ = function() {
+        return this.__bool__().__not__();
+    };
+
+    Dict.prototype.__invert__ = function() {
+        throw new batavia.builtins.TypeError("bad operand type for unary ~: 'dict'");
+    };
+
+    /**************************************************
+     * Binary operators
+     **************************************************/
+
+    Dict.prototype.__pow__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for ** or pow(): 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+    Dict.prototype.__div__ = function(other) {
+        return this.__truediv__(other);
+    };
+
+    Dict.prototype.__floordiv__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for //: 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+    Dict.prototype.__truediv__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for /: 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+    Dict.prototype.__mul__ = function(other) {
+        if (batavia.isinstance(other, [
+                batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
+                batavia.types.JSDict, batavia.types.Int, batavia.types.NoneType])) {
+            throw new batavia.builtins.TypeError("unsupported operand type(s) for *: 'dict' and '" + batavia.type_name(other) + "'");
+        } else {
+            throw new batavia.builtins.TypeError("can't multiply sequence by non-int of type 'dict'");
+        }
+    };
+
+    Dict.prototype.__mod__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__mod__ has not been implemented");
+    };
+
+    Dict.prototype.__add__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for +: 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+    Dict.prototype.__sub__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for -: 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+
+    Dict.prototype.__lshift__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__lshift__ has not been implemented");
+    };
+
+    Dict.prototype.__rshift__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__rshift__ has not been implemented");
+    };
+
+    Dict.prototype.__and__ = function(other) {
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for &: 'dict' and '" + batavia.type_name(other) + "'");
+    };
+
+    Dict.prototype.__xor__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__xor__ has not been implemented");
+    };
+
+    Dict.prototype.__or__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__or__ has not been implemented");
+    };
+
+    Dict.prototype.__setitem__ = function(key, value) {
+        if (this.size + 1 > this.data_keys.length * MAX_LOAD_FACTOR) {
+            this._increase_size();
+        }
+        var hash = batavia.builtins.hash([key], null);
+        var h = hash.int32() & this.mask;
+        while (true) {
+            var current_key = this.data_keys[h];
+            if (isEmpty(current_key) || isDeleted(current_key)) {
+                this.data_keys[h] = key;
+                this.data_values[h] = value;
+                this.size++;
+                return;
+            } else if (current_key === null && key === null) {
+                this.data_keys[h] = key;
+                this.data_values[h] = value;
+                return;
+            } else if (batavia.builtins.hash([current_key], null).__eq__(hash).valueOf() &&
+                       current_key.__eq__(key).valueOf()) {
+                 this.data_keys[h] = key;
+                 this.data_values[h] = value;
+            }
+
+            h = (h + 1) & this.mask;
+            if (h == (hash.int32() & this.mask)) {
+                // we have looped, we'll rehash
+                this._increase_size();
+                h = hash.int32() & this.mask;
+            }
+        }
+    };
+
+    /**************************************************
+     * Inplace operators
+     **************************************************/
+
+    Dict.prototype.__ifloordiv__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__ifloordiv__ has not been implemented");
+    };
+
+    Dict.prototype.__itruediv__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__itruediv__ has not been implemented");
+    };
+
+    Dict.prototype.__iadd__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__iadd__ has not been implemented");
+    };
+
+    Dict.prototype.__isub__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__isub__ has not been implemented");
+    };
+
+    Dict.prototype.__imul__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__imul__ has not been implemented");
+    };
+
+    Dict.prototype.__imod__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__imod__ has not been implemented");
+    };
+
+    Dict.prototype.__ipow__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__ipow__ has not been implemented");
+    };
+
+    Dict.prototype.__ilshift__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__ilshift__ has not been implemented");
+    };
+
+    Dict.prototype.__irshift__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__irshift__ has not been implemented");
+    };
+
+    Dict.prototype.__iand__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__iand__ has not been implemented");
+    };
+
+    Dict.prototype.__ixor__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__ixor__ has not been implemented");
+    };
+
+    Dict.prototype.__ior__ = function(other) {
+        throw new batavia.builtins.NotImplementedError("Dict.__ior__ has not been implemented");
+    };
+
+    Dict.prototype._find_index = function(other) {
+        if (this.size === 0) {
+            return null;
+        }
+        var hash = batavia.builtins.hash([other], null);
+        var h = hash.int32() & this.mask;
+        while (true) {
+            var key = this.data_keys[h];
+            if (isDeleted(key)) {
+                h = (h + 1) & this.mask;
+                continue;
+            }
+            if (isEmpty(key)) {
+                return null;
+            }
+            if (key === null && other === null) {
+                return h;
+            }
+            if (batavia.builtins.hash([key], null).__eq__(hash).valueOf() &&
+                ((key === null && other === null) || key.__eq__(other).valueOf())) {
+                return h;
+            }
+            h = (h + 1) & this.mask;
+
+            if (h == (hash.int32() & this.mask)) {
+                // we have looped, definitely not here
+                return null;
+            }
+        }
+    };
+
+    Dict.prototype.__contains__ = function(key) {
+        return new batavia.types.Bool(this._find_index(key) !== null);
+    };
+
+    Dict.prototype.__getitem__ = function(key) {
+        var i = this._find_index(key);
+        if (i === null) {
+            throw new batavia.builtins.KeyError(key === null ? 'None': key);
+        }
+        return this.data_values[i];
+    };
+
+    Dict.prototype.__delitem__ = function(key) {
+        var i = this._find_index(key);
+        if (i === null) {
+            throw new batavia.builtins.KeyError(key === null ? 'None': key);
+        }
+        this.data_keys[i] = DELETED;
+        this.data_values[i] = null;
+        this.size--;
+    };
+
+    /**************************************************
+     * Methods
+     **************************************************/
+
+    Dict.prototype.get = function(key, backup) {
+        var i = this._find_index(other);
+        if (i !== null) {
+            return this.data_values[i];
+        } else if (typeof backup === 'undefined') {
+            throw new batavia.builtins.KeyError(key === null ? 'None': key);
+        } else {
+            return backup;
+        }
+    };
+
+    Dict.prototype.update = function(values) {
+        var updates;
+        if (batavia.isinstance(values, [batavia.types.Dict, batavia.types.JSDict])) {
+            updates = batavia.builtins.iter([values.items()], null);
+        } else {
+            updates = batavia.builtins.iter([values], null);
+        }
+        var i = 0;
+        var self = this;
+        batavia.iter_for_each(updates, function(val) {
+            var pieces = new batavia.types.Tuple(val);
+            if (pieces.length != 2) {
+                throw new batavia.builtins.ValueError("dictionary update sequence element #" + i + " has length " + piece.length + "; 2 is required");
+            }
+            var key = pieces[0];
+            var value = pieces[1];
+            // we can partially process
+            self.__setitem__(key, value);
+            i++;
+        });
+    };
+
+    Dict.prototype.copy = function() {
+        return new Dict(this);
+    };
+
+    Dict.prototype.items = function() {
+        var result = new batavia.types.List();
+        for (var i = 0; i < this.data_keys.length; i++) {
+            // ignore deleted or empty
+            var key = this.data_keys[i];
+            if (isEmpty(key) || isDeleted(key)) {
+                continue;
+            }
+            result.append(new batavia.types.Tuple([key, this.data_values[i]]));
+        }
+        return result;
+    };
+
+    Dict.prototype.keys = function() {
+        var result = new batavia.types.List();
+        for (var i = 0; i < this.data_keys.length; i++) {
+            // ignore deleted or empty
+            var key = this.data_keys[i];
+            if (isEmpty(key) || isDeleted(key)) {
+                continue;
+            }
+            result.append(key);
+        }
+        return result;
+    };
+
+    Dict.prototype.__iter__ = function() {
+        return batavia.builtins.iter([this.keys()], null);
+    };
+
+    Dict.prototype.values = function() {
+        var result = new batavia.types.List();
+        for (var i = 0; i < this.data_keys.length; i++) {
+            // ignore deleted or empty
+            var key = this.data_keys[i];
+            if (isEmpty(key) || isDeleted(key)) {
+                continue;
+            }
+            result.append(this.data_values[i]);
+        }
+        return result;
+    };
+
+    Dict.prototype.clear = function() {
+        this.size = 0;
+        this.mask = 0;
+        this.data_keys = [];
+        this.data_values = [];
+    };
 
     return Dict;
 }();

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -312,7 +312,7 @@ batavia.types.Int = function() {
                 throw new batavia.builtins.MemoryError("");
             }
             result = new batavia.types.List();
-            for (i = 0; i < this.valueOf(); i++) {
+            for (var i = 0; i < this.valueOf(); i++) {
                 result.extend(other);
             }
             return result;

--- a/batavia/types/JSDict.js
+++ b/batavia/types/JSDict.js
@@ -17,7 +17,7 @@ batavia.types.JSDict = function() {
      * Javascript compatibility methods
      **************************************************/
 
-    JSDict.prototype.toString = function () {
+    JSDict.prototype.toString = function() {
         return this.__str__();
     };
 
@@ -33,7 +33,7 @@ batavia.types.JSDict = function() {
         return this.__str__();
     };
 
-    JSDict.prototype.__str__ = function () {
+    JSDict.prototype.__str__ = function() {
         var result = "{", values = [];
         for (var key in this) {
             if (this.hasOwnProperty(key)) {
@@ -132,19 +132,19 @@ batavia.types.JSDict = function() {
      **************************************************/
 
     JSDict.prototype.__pos__ = function() {
-        return new Dict(+this.valueOf());
+        throw new batavia.builtins.TypeError("bad operand type for unary +: 'jsdict'");
     };
 
     JSDict.prototype.__neg__ = function() {
-        return new Dict(-this.valueOf());
+        throw new batavia.builtins.TypeError("bad operand type for unary -: 'jsdict'");
     };
 
     JSDict.prototype.__not__ = function() {
-        return new Dict(!this.valueOf());
+        return this.__bool__().__not__();
     };
 
     JSDict.prototype.__invert__ = function() {
-        return new Dict(~this.valueOf());
+        throw new batavia.builtins.TypeError("bad operand type for unary ~: 'jsdict'");
     };
 
     /**************************************************
@@ -152,7 +152,7 @@ batavia.types.JSDict = function() {
      **************************************************/
 
     JSDict.prototype.__pow__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for ** or pow(): 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for ** or pow(): 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
     JSDict.prototype.__div__ = function(other) {
@@ -160,20 +160,20 @@ batavia.types.JSDict = function() {
     };
 
     JSDict.prototype.__floordiv__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for //: 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for //: 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
     JSDict.prototype.__truediv__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for /: 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for /: 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
     JSDict.prototype.__mul__ = function(other) {
         if (batavia.isinstance(other, [
                 batavia.types.Bool, batavia.types.Dict, batavia.types.Float,
                 batavia.types.JSDict, batavia.types.Int, batavia.types.NoneType])) {
-            throw new batavia.builtins.TypeError("unsupported operand type(s) for *: 'dict' and '" + batavia.type_name(other) + "'");
+            throw new batavia.builtins.TypeError("unsupported operand type(s) for *: 'jsdict' and '" + batavia.type_name(other) + "'");
         } else {
-            throw new batavia.builtins.TypeError("can't multiply sequence by non-int of type 'dict'");
+            throw new batavia.builtins.TypeError("can't multiply sequence by non-int of type 'jsdict'");
         }
     };
 
@@ -182,19 +182,15 @@ batavia.types.JSDict = function() {
     };
 
     JSDict.prototype.__add__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for +: 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for +: 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
     JSDict.prototype.__sub__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for -: 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for -: 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
-    JSDict.prototype.__getitem__ = function(other) {
-        var value = this[other];
-        if (value === undefined) {
-            throw new batavia.builtins.KeyError(other === null ? 'None': other.__str__());
-        }
-        return value;
+    JSDict.prototype.__setitem__ = function(key, value) {
+        this[key] = value;
     };
 
     JSDict.prototype.__lshift__ = function(other) {
@@ -206,7 +202,7 @@ batavia.types.JSDict = function() {
     };
 
     JSDict.prototype.__and__ = function(other) {
-        throw new batavia.builtins.TypeError("unsupported operand type(s) for &: 'dict' and '" + batavia.type_name(other) + "'");
+        throw new batavia.builtins.TypeError("unsupported operand type(s) for &: 'jsdict' and '" + batavia.type_name(other) + "'");
     };
 
     JSDict.prototype.__xor__ = function(other) {
@@ -269,6 +265,21 @@ batavia.types.JSDict = function() {
         throw new batavia.builtins.NotImplementedError("Dict.__ior__ has not been implemented");
     };
 
+    JSDict.prototype.__getitem__ = function(other) {
+        var value = this[other];
+        if (value === undefined) {
+            throw new batavia.builtins.KeyError(other === null ? 'None': other.__str__());
+        }
+        return value;
+    };
+
+    JSDict.prototype.__delitem__ = function(key) {
+        if (!this.__contains__(key)) {
+            throw new batavia.builtins.KeyError(key === null ? 'None': key);
+        }
+        delete this[key];
+    };
+
     /**************************************************
      * Methods
      **************************************************/
@@ -277,7 +288,7 @@ batavia.types.JSDict = function() {
         if (this.__contains__(key)) {
             return this[key];
         } else if (typeof backup === 'undefined') {
-            return null;
+            throw new batavia.builtins.KeyError(key === null ? 'None': key);
         } else {
             return backup;
         }
@@ -292,14 +303,14 @@ batavia.types.JSDict = function() {
     };
 
     JSDict.prototype.copy = function() {
-        return new Dict(this);
+        return new JSDict(this);
     };
 
     JSDict.prototype.items = function() {
-        var result = [];
+        var result = new batavia.types.List();
         for (var key in this) {
             if (this.hasOwnProperty(key)) {
-                result.push([key, this[key]]);
+                result.append(new batavia.types.Tuple([key, this[key]]));
             }
         }
         return result;
@@ -315,6 +326,10 @@ batavia.types.JSDict = function() {
         return new batavia.types.List(result);
     };
 
+    JSDict.prototype.__iter__ = function() {
+        return this.keys().__iter__();
+    };
+
     JSDict.prototype.values = function() {
         var result = [];
         for (var key in this) {
@@ -323,6 +338,12 @@ batavia.types.JSDict = function() {
             }
         }
         return new batavia.types.List(result);
+    };
+
+    JSDict.prototype.clear = function() {
+        for (var key in this) {
+            delete this[key];
+        }
     };
 
     return JSDict;

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -274,7 +274,7 @@ batavia.types.List = function() {
             if(other <= 0) {
                 return result;
             } else {
-                for (i = 0; i < other; i++) {
+                for (var i = 0; i < other; i++) {
                     result.extend(this);
                 }
                 return result;
@@ -297,11 +297,11 @@ batavia.types.List = function() {
     List.prototype.__add__ = function(other) {
         if (batavia.isinstance(other, batavia.types.List)) {
             result = new List();
-                for (i=0; i < this.length; i++){
+                for (var i = 0; i < this.length; i++) {
                     result.push(this[i]);
                 }
 
-                for (i=0; i < other.length; i++){
+                for (var i = 0; i < other.length; i++) {
                     result.push(other[i]);
                 }
 

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -187,7 +187,7 @@ batavia.types.Tuple = function() {
     Tuple.prototype.__mul__ = function(other) {
         if (batavia.isinstance(other, batavia.types.Int)) {
             result = new List();
-            for (i = 0; i < other.valueOf(); i++) {
+            for (var i = 0; i < other.valueOf(); i++) {
                 result.extend(this);
             }
             return result;
@@ -211,11 +211,11 @@ batavia.types.Tuple = function() {
 			throw new batavia.builtins.TypeError('can only concatenate tuple (not "' + batavia.type_name(other) + '") to tuple')
 		} else {
 			result = new Tuple();
-			for (i=0; i < this.length; i++){
+			for (var i = 0; i < this.length; i++){
 				result.push(this[i]);
 			}
 
-			for (i=0; i < other.length; i++){
+			for (var i = 0; i < other.length; i++){
 				result.push(other[i]);
 			}
 

--- a/batavia/utils.js
+++ b/batavia/utils.js
@@ -251,7 +251,7 @@ batavia.make_callable = function(func) {
             'code': func.__code__,
             'callargs': callargs,
             'f_globals': func.__globals__,
-            'f_locals': locals || new batavia.types.Dict()
+            'f_locals': locals || new batavia.types.JSDict()
         });
 
         if (func.__code__.co_flags & batavia.modules.dis.CO_GENERATOR) {

--- a/tests/builtins/test_all.py
+++ b/tests/builtins/test_all.py
@@ -25,7 +25,6 @@ class BuiltinAllFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
 
         'test_bytearray',
-        'test_dict',
         'test_complex',
         'test_NotImplemented',
         'test_range',

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -27,8 +27,15 @@ class DictTests(TranspileTestCase):
             print(x)
             """)
 
+        # normal key
         self.assertCodeExecution("""
             x = {'a': 1}
+            print(x)
+            """)
+
+        # keys with the same string representation
+        self.assertCodeExecution("""
+            x = {1: 2, '1': 1}
             print(x)
             """)
 
@@ -50,7 +57,6 @@ class DictTests(TranspileTestCase):
             print(x['c'])
             """, run_in_function=False)
 
-    @unittest.expectedFailure
     def test_clear(self):
         # Clear a dictionary
         self.assertCodeExecution("""
@@ -157,13 +163,6 @@ class DictTests(TranspileTestCase):
 
 class UnaryDictOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'dict'
-
-    not_implemented = [
-        'test_unary_positive',
-        'test_unary_negative',
-        'test_unary_not',
-        'test_unary_invert',
-    ]
 
 
 class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
@@ -300,22 +299,15 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_rshift_str',
         'test_rshift_tuple',
 
-        'test_subscr_bool',
         'test_subscr_bytearray',
-        'test_subscr_bytes',
         'test_subscr_class',
-        'test_subscr_complex',
         'test_subscr_dict',
-        'test_subscr_float',
-        'test_subscr_frozenset',
         'test_subscr_None',
         'test_subscr_NotImplemented',
-        'test_subscr_int',
         'test_subscr_list',
         'test_subscr_range',
         'test_subscr_set',
         'test_subscr_slice',
-        'test_subscr_tuple',
 
         'test_xor_bool',
         'test_xor_bytearray',


### PR DESCRIPTION
This fixes the problem where `{1: 2, "1": 3}` would produce either `{1: 2}` or `{1: 3}`. It also gives us control over hash table performance, although it is probably slower than the native JS objects.

I also fixed a few other things while I was in here:

* There were a bunch of leaky global variables I found in for-loops (found when debugging something else)
* A spurious console.log in the frozenset unmarhsaling
* A few times `args` was used in functions without checking if it is null.

Whew!