### PR TITLE
Struct_time

### DIFF
--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -26,18 +26,20 @@ batavia.modules.time = {
 
 batavia.modules.time.struct_time = function (sequence) {
     /*
-        copied from https://docs.python.org/2/library/time.html#time.struct_time
-        WHAT ATTRIBUTION DOES THIS NEED?
+        copied from https://docs.python.org/3/library/time.html#time.struct_time
 
-        0 	tm_year 	(for example, 1993)
-        1 	tm_mon 	    range [1, 12]
-        2 	tm_mday 	range [1, 31]
-        3 	tm_hour 	range [0, 23]
-        4 	tm_min 	    range [0, 59]
-        5 	tm_sec 	    range [0, 61]; see (2) in strftime() description
-        6 	tm_wday 	range [0, 6], Monday is 0
-        7 	tm_yday 	range [1, 366]
-        8 	tm_isdst 	0, 1 or -1; see below
+        Index 	Attribute 	Values
+        0 	    tm_year 	(for example, 1993)
+        1 	    tm_mon 	    range [1, 12]
+        2 	    tm_mday 	range [1, 31]
+        3 	    tm_hour 	range [0, 23]
+        4 	    tm_min 	    range [0, 59]
+        5 	    tm_sec 	    range [0, 61]; see (2) in strftime() description
+        6 	    tm_wday 	range [0, 6], Monday is 0
+        7 	    tm_yday 	range [1, 366]
+        8 	    tm_isdst 	0, 1 or -1; see below
+        N/A 	tm_zone 	abbreviation of timezone name
+        N/A 	tm_gmtoff 	offset east of UTC in seconds
     */
 
 
@@ -64,7 +66,7 @@ batavia.modules.time.struct_time = function (sequence) {
 
             var items = new batavia.types.Tuple(sequence);
 
-        } else if (batavia.isinstance(sequence, batavia.types.Dict){
+        } else if (batavia.isinstance(sequence, batavia.types.Dict)){
 
             var items = sequence.keys();
 

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -23,3 +23,83 @@ batavia.modules.time = {
         }
     }
 };
+
+batavia.modules.time.struct_time = function (sequence) {
+    /*
+        copied from https://docs.python.org/2/library/time.html#time.struct_time
+        WHAT ATTRIBUTION DOES THIS NEED?
+
+        0 	tm_year 	(for example, 1993)
+        1 	tm_mon 	    range [1, 12]
+        2 	tm_mday 	range [1, 31]
+        3 	tm_hour 	range [0, 23]
+        4 	tm_min 	    range [0, 59]
+        5 	tm_sec 	    range [0, 61]; see (2) in strftime() description
+        6 	tm_wday 	range [0, 6], Monday is 0
+        7 	tm_yday 	range [1, 366]
+        8 	tm_isdst 	0, 1 or -1; see below
+    */
+
+
+    if (batavia.isinstance(sequence, [batavia.types.Bytearray, batavia.types.Bytes, batavia.types.Dict,
+        batavia.types.FrozenSet, batavia.types.List, batavia.types.Range, batavia.types.Set, batavia.types.Str,
+        batavia.types.Tuple]
+        )){
+
+        if (sequence.length < 9){
+            throw new batavia.builtins.TypeError("time.struct_time() takes an at least 9-sequence ("+sequence.length+"-sequence given)")
+        } else if (sequence.length > 11) {
+            throw new batavia.builtins.TypeError("time.struct_time() takes an at most 11-sequence ("+sequence.length+"-sequence given)")
+        }
+
+        // might need to convert sequence to a more manageable type
+        if (batavia.isinstance(sequence, [batavia.types.Bytearray])){
+            // dict won't work until .keys() is implemented
+            // bytearray won't work until .__iter__ is implemented
+
+            throw new batavia.builtins.NotImplementedError("not implemented for "+ batavia.type_name(sequence)+".")
+
+        } else if (batavia.isinstance(sequence, [batavia.types.Bytes, batavia.types.FrozenSet,
+            batavia.types.Set, batavia.types.Range])) {
+
+            var items = new batavia.types.Tuple(sequence);
+
+        } else if (batavia.isinstance(sequence, batavia.types.Dict){
+
+            var items = sequence.keys();
+
+        } else {
+            // friendly type, no extra processing needed
+            var items = sequence;
+        }
+
+        this.n_fields = 11;
+        this.n_unnamed_fields = 0;
+        this.n_sequence_fields = 9;
+
+       this.push.apply(this, items.slice(0,9));  // only first 9 elements accepted for __getitem__
+
+        var attrs = [ 'tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min', 'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst',
+            'tm_zone', 'tm_gmtoff']
+
+        for (var i=0; i<items.length; i++){
+            this[attrs[i]] = items[i];
+        }
+
+    } else {
+        //some other, unacceptable type
+        throw new batavia.builtins.TypeError("constructor requires a sequence");
+    }
+}
+
+batavia.modules.time.struct_time.prototype = new batavia.types.Tuple();
+
+batavia.modules.time.struct_time.prototype.__str__ = function(){
+    return "time.struct_time(tm_year="+this.tm_year+", tm_mon="+this.tm_mon+", tm_mday="+this.tm_mday+", tm_hour="+this.tm_hour+", tm_min="+this.tm_min+", tm_sec="+this.tm_sec+", tm_wday="+this.tm_wday+", tm_yday="+this.tm_yday+", tm_isdst="+this.tm_isdst+")"
+}
+
+batavia.modules.time.struct_time.prototype.__repr__ = function(){
+    return this.__str__()
+}
+
+//TODO __reduce__

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -34,3 +34,141 @@ class TimeTests(TranspileTestCase):
                 print(err)
             print('Done.')
             """)
+
+    @unittest.expectedFailure
+    def test_struct_time_valid(self):
+        """
+        valid construction
+        """
+
+        # TODO: this won't pass until bytearay is iterable
+
+        seed = list(range(1, 10))
+        sequences = (
+            bytearray(seed),
+            bytes(seed),
+            dict(zip(seed, seed)),
+            frozenset(seed),
+            seed,
+            range(1, 10),
+            set(seed),
+            ''.join([str(i) for i in seed]),
+            tuple(seed)
+        )
+
+        for seq in sequences:
+            self.assertCodeExecution(struct_time_setup(seq))
+
+    def test_struct_time_valid_lengths(self):
+        """
+        length 9, 10, 11 are acceptable
+        """
+
+        for size in range(9, 12):
+            test_str = struct_time_setup([1] * size)
+            self.assertCodeExecution(test_str)
+
+    def test_struct_time_invalid(self):
+        """
+        invalid construction due to bad type
+        """
+
+        bad_types = [
+            True,
+            0j,
+            1,
+            None,
+            NotImplemented
+        ]
+
+        for t in bad_types:
+            self.assertCodeExecution(struct_time_setup(t))
+
+
+    def test_struct_time_too_short(self):
+        """
+        sequence less than length 9 is passed
+        should raise an index error
+        """
+        self.assertCodeExecution(struct_time_setup([1]*8))
+
+
+    def test_struct_time_too_long(self):
+        """
+        sequence longer than length 9 is allowed
+        """
+        self.assertCodeExecution(struct_time_setup([1]*12))
+
+    def test_struct_time_attrs(self):
+        """
+        tests for struct_time attributes
+        """
+
+        setup = struct_time_setup()
+
+        fields = ['n_fields', 'n_unnamed_fields', 'n_sequence_fields', 'tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min',
+                  'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst', 'tm_zone', 'tm_gmtoff']
+        test_strs = [adjust("""
+            print('>>> st.{attr}')
+            print(st.{attr})
+        """.format(attr=attr)) for attr in fields]
+
+        self.assertCodeExecution(setup + ''.join(test_strs))
+
+    def test_get_item(self):
+        """
+        tries __getitem__ for index -12-12
+        """
+
+        setup = struct_time_setup([1] * 11)
+        get_indecies = [adjust("""
+        print('>>> st[{i}]')
+        print(st[{i}])
+        """)for i in range(-12, 13)]
+
+        self.assertCodeExecution(setup + ''.join(get_indecies))
+
+    def test_struct_time_str(self):
+        """
+        tests the str method
+        """
+
+        test_str = struct_time_setup()
+        test_str += adjust("""
+        print('>>> str(st)')
+        print(str(st))
+        """)
+
+        self.assertCodeExecution(adjust(test_str))
+
+    def test_struct_time_repr(self):
+        """
+        tests the repr method
+        """
+
+        test_str = struct_time_setup()
+        test_str += adjust("""
+        print('>>> repr(st)')
+        print(repr(st))
+        """)
+
+        self.assertCodeExecution(adjust(test_str))
+
+
+def struct_time_setup(seq = [1] * 9):
+    """
+    returns a string to set up a struct_time with seq the struct_time constructor
+    :param seq: a valid sequence
+    """
+
+    test_str = adjust("""
+    print("constructing struct_time with {type_name}")
+    print('>>> import time')
+    import time
+    print(">>> st = time.struct_time({seq})")
+    st = time.struct_time({seq})
+    print('>>> st')
+    print(st)
+    """).format(type_name=type(seq), seq=seq)
+
+    return test_str


### PR DESCRIPTION
this PR replaces [this one](https://github.com/pybee/batavia/pull/285#discussion_r81440328 ). The other PR contained a confusing git history and this one is (hopefully) more clear.

Also:

- simplified tests to make only one assertion per test
- implemented constructor to accept `dict`
- throw `NotImplemented` for `bytearray`
- alter tests to match.

Any other comments?