### PR TITLE
Normalize dictionary keys to list ordering in tests

### DIFF
--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -11,7 +11,6 @@ class BuiltinListFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_bytearray',
         'test_complex',
-        'test_dict',
         'test_NotImplemented',
         'test_range',
     ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -819,6 +819,15 @@ SAMPLE_SUBSTITUTIONS = {
         "('another', 2.3456, 1)",
         "(2.3456, 'another', 1)",
     ],
+    # Normalize dictionary keys to list ordering
+    "['c', 'd', 'a']": [
+        "['a', 'c', 'd']",
+        "['a', 'd', 'c']",
+        "['c', 'a', 'd']",
+        "['c', 'd', 'a']",
+        "['d', 'a', 'c']",
+        "['d', 'c', 'a']",
+    ],
     # Normalize precision error
     "-0.00000265358979335273": ["-2.65358979335273e-6",],
     "-0.0000026535897933527304": ["-2.6535897933527304e-6",],


### PR DESCRIPTION
I noticed that this test had an unexpected success once or twice. It was because 1/6 times it would pass, depending on how the dictionary ordering.