### PR TITLE
mktime

### DIFF
--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -110,41 +110,32 @@ batavia.modules.time.mktime = function(sequence){
 
     //Validations
     if (arguments.length != 1){
-        throw new batavia.builtins.TypeError("mktime() takes exactly one argument ("+arguments.length+" given)")
+        throw new batavia.builtins.TypeError("mktime() takes exactly one argument ("+arguments.length+" given)");
     }
 
     if (!batavia.isinstance(sequence, [batavia.types.Tuple, batavia.modules.time.struct_time])) {
-        throw new batavia.builtins.TypeError("Tuple or struct_time argument required")
+        throw new batavia.builtins.TypeError("Tuple or struct_time argument required");
     }
 
     if (sequence.length !== 9){
-        throw new batavia.builtins.TypeError("function takes exactly 9 arguments ("+sequence.length+" given)")
+        throw new batavia.builtins.TypeError("function takes exactly 9 arguments ("+sequence.length+" given)");
+    }
+
+    if (sequence[0] < 1900){
+        // because the earliest possible date is system dependant, use an arbitrary cut off for now.
+        throw new batavia.builtins.OverflowError("mktime argument out of range");
     }
 
     // all items must be integers
     for (var i=0; i<sequence.length; i++){
-        var item = sequence[i]
+        var item = sequence[i];
         if (batavia.isinstance(item, batavia.types.Float)){
             throw new batavia.builtins.TypeError("integer argument expected, got float")
         }
         else if (!batavia.isinstance(item, [batavia.types.Int])){
-            throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
+            throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")");
         }
     }
-
-    /* TODO
-    phantomjs interprets a 2 digit year as being in the 20th century not the first. Example:
-
-    phantomjs> new Date(70, 01, 01, 0, 0, 0, 0, 0).getTime()
-    2696400000
-    phantomjs> new Date(1970, 01, 01, 0, 0, 0, 0, 0).getTime()
-    2696400000     //wat
-
-    If handed a 2 digit year, should the function:
-        1. assume its in the 20th century,
-        2. throw some kind of error
-        3. do something else?
-    */
 
     var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
     return seconds.toFixed(1);

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -105,15 +105,30 @@ batavia.modules.time.struct_time.prototype.__repr__ = function(){
 }
 
 batavia.modules.time.mktime = function(sequence){
+    // sequence: struct_time like
     // documentation: https://docs.python.org/3/library/time.html#time.mktime
-    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
 
-    if (seconds === Math.floor(seconds)){
-        // need special handling when a number with no decimal places is returned
-        return parseFloat(seconds).toFixed(1);
-    } else {
-        return seconds;
-    }
+    //can't be a float:
+//        throw new batavia.builtins.TypeError("integer argument expected, got float")
+
+    // try to convert to int, throw error if fail:
+//        throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
+
+
+//    // all items must be integers
+//    for (var i in sequence){
+//        var item = sequence[i]
+//        if (batavia.isinstance(item, batavia.types.Float)){
+//            throw new batavia.builtins.TypeError("integer argument expected, got float")
+//        }
+//        if (batavia.isinstance(item, [batavia.types.Str])) {
+//            throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
+//        }
+//    }
+
+    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5],
+        0).getTime() / 1000;
+    return seconds;
 
 }
 

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -137,6 +137,14 @@ batavia.modules.time.mktime = function(sequence){
         }
     }
 
-    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
+    var date = new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0)
+
+    if (isNaN(date)){
+        // date is too large per ECMA specs
+        // source: http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.1
+        throw new batavia.builtins.OverflowError("signed integer is greater than maximum")
+    }
+
+    var seconds = date.getTime() / 1000;
     return seconds.toFixed(1);
 }

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -104,4 +104,17 @@ batavia.modules.time.struct_time.prototype.__repr__ = function(){
     return this.__str__()
 }
 
+batavia.modules.time.mktime = function(sequence){
+    // documentation: https://docs.python.org/3/library/time.html#time.mktime
+    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
+
+    if (seconds === Math.floor(seconds)){
+        // need special handling when a number with no decimal places is returned
+        return parseFloat(seconds).toFixed(1);
+    } else {
+        return seconds;
+    }
+
+}
+
 //TODO __reduce__

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -108,32 +108,44 @@ batavia.modules.time.mktime = function(sequence){
     // sequence: struct_time like
     // documentation: https://docs.python.org/3/library/time.html#time.mktime
 
+    //Validations
+    if (arguments.length != 1){
+        throw new batavia.builtins.TypeError("mktime() takes exactly one argument ("+arguments.length+" given)")
+    }
 
     if (!batavia.isinstance(sequence, [batavia.types.Tuple, batavia.modules.time.struct_time])) {
         throw new batavia.builtins.TypeError("Tuple or struct_time argument required")
     }
 
+    if (sequence.length !== 9){
+        throw new batavia.builtins.TypeError("function takes exactly 9 arguments ("+sequence.length+" given)")
+    }
+
     // all items must be integers
-    for (var i in sequence){
+    for (var i=0; i<sequence.length; i++){
         var item = sequence[i]
         if (batavia.isinstance(item, batavia.types.Float)){
             throw new batavia.builtins.TypeError("integer argument expected, got float")
         }
-        else if (!batavia.isinstance(item, batavia.types.Int)) {
+        else if (!batavia.isinstance(item, [batavia.types.Int])){
             throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
         }
     }
 
-    //earliest possible date on my Mac
-    //(1901, 12, 13, 15, 45, 52, 0, 0, 0)
-//    if (sequence < batavia.types.Tuple([1901, 12, 13, 15, 45, 52, 0, 0, 0])){
-//        throw new batavia.builtins.OverflowError("mktime argument out of range")
-//    }
+    /* TODO
+    phantomjs interprets a 2 digit year as being in the 20th century not the first. Example:
 
+    phantomjs> new Date(70, 01, 01, 0, 0, 0, 0, 0).getTime()
+    2696400000
+    phantomjs> new Date(1970, 01, 01, 0, 0, 0, 0, 0).getTime()
+    2696400000     //wat
+
+    If handed a 2 digit year, should the function:
+        1. assume its in the 20th century,
+        2. throw some kind of error
+        3. do something else?
+    */
 
     var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
     return seconds.toFixed(1);
-
 }
-
-//TODO __reduce__

--- a/batavia/modules/time.js
+++ b/batavia/modules/time.js
@@ -108,27 +108,31 @@ batavia.modules.time.mktime = function(sequence){
     // sequence: struct_time like
     // documentation: https://docs.python.org/3/library/time.html#time.mktime
 
-    //can't be a float:
-//        throw new batavia.builtins.TypeError("integer argument expected, got float")
 
-    // try to convert to int, throw error if fail:
-//        throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
+    if (!batavia.isinstance(sequence, [batavia.types.Tuple, batavia.modules.time.struct_time])) {
+        throw new batavia.builtins.TypeError("Tuple or struct_time argument required")
+    }
 
+    // all items must be integers
+    for (var i in sequence){
+        var item = sequence[i]
+        if (batavia.isinstance(item, batavia.types.Float)){
+            throw new batavia.builtins.TypeError("integer argument expected, got float")
+        }
+        else if (!batavia.isinstance(item, batavia.types.Int)) {
+            throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
+        }
+    }
 
-//    // all items must be integers
-//    for (var i in sequence){
-//        var item = sequence[i]
-//        if (batavia.isinstance(item, batavia.types.Float)){
-//            throw new batavia.builtins.TypeError("integer argument expected, got float")
-//        }
-//        if (batavia.isinstance(item, [batavia.types.Str])) {
-//            throw new batavia.builtins.TypeError("an integer is required (got type " + batavia.type_name(item) + ")")
-//        }
+    //earliest possible date on my Mac
+    //(1901, 12, 13, 15, 45, 52, 0, 0, 0)
+//    if (sequence < batavia.types.Tuple([1901, 12, 13, 15, 45, 52, 0, 0, 0])){
+//        throw new batavia.builtins.OverflowError("mktime argument out of range")
 //    }
 
-    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5],
-        0).getTime() / 1000;
-    return seconds;
+
+    var seconds =  new Date(sequence[0], sequence[1] - 1, sequence[2], sequence[3], sequence[4], sequence[5], 0).getTime() / 1000;
+    return seconds.toFixed(1);
 
 }
 

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -180,37 +180,99 @@ class TimeTests(TranspileTestCase):
 
     # TESTS FOR MKTIME
     def test_mktime(self):
-        self.assertCodeExecution(mktime_setup())
+
+        seq = (1970,1,1,0,0,0,0,0,0)
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        print('>>> seq = {seq}')
+        seq = {seq}
+        print(">>> time.mktime(seq)")
+        print(time.mktime(seq))
+        #################################
+        print('>>> seq = time.struct_time({seq})')
+        seq = time.struct_time({seq})
+        print(">>> time.mktime(seq)")
+        print(time.mktime(seq))
+        """).format(seq=seq)
+
+        self.assertCodeExecution(test_str)
 
     def test_mktime_bad_input(self):
         """
-        TypeError: Tuple or struct_time argument required
+        when the argument passed is not tuple or struct_time. This error is thrown
+        expected error TypeError: Tuple or struct_time argument required
         """
 
-        bad_types=[
+        seed = (1970,1,1,0,0,0,0,0,0)
 
-
+        data = [
+            False,
+            1j,
+            {key: key for key in seed},
+            1.2,
+            frozenset(seed),
+            1,
+            list(seed),
+            range(1,2,3),
+            set(seed),
+            slice(1,2,3),
+            '123456789',
+            None,
+            NotImplemented
         ]
 
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        """)
+
+        tests = [mktime_setup(str(d)) for d in data]
+        test_str += ''.join(tests)
+
+        self.assertCodeExecution(test_str)
+
+    # def test_mktime_overflow(self):
+    #     """
+    #     argument is too small or large and throws this error:
+    #     OverflowError: mktime argument out of range
+    #
+    #     :return:
+    #     """
+    #
+    #     test_str = adjust("""
+    #     print('>>> import time')
+    #     import time
+    #     """)
+    #
+    #     sequences = [
+    #         (1901, 12, 13, 0, 0, 0, 0, 0, 0),
+    #
+    #     ]
 
     def test_mktime_non_integer_types(self):
+        """
+        tests behavior when non integer types are part of the sequence passed
+        """
 
-        strange_types = [
-            True,
-            bytearray
+        strange_types = [ SAMPLE_DATA[type][0] for type in SAMPLE_DATA if type != 'int' ]
 
-        ]
-
-        tests = [ mktime_setup( (1970, t, 1, 2, 0, 0, 0, 0, 0) ) for t in strange_types]
+        tests = [ mktime_setup( str((1970, t, 1, 2, 0, 0, 0, 0, 0)) ) for t in strange_types]
         test_str = ''.join(tests)
 
         self.assertCodeExecution(test_str)
-        # seq = (1970, .5, 1,2,0,0,0,0,0)
-        # st = struct_time(seq)
-        # test_str = mktime_setup(seq)
-        # self.assertCodeExecution(test_str)
 
-    def
+    def test_mktime_seq_wrong_length(self):
+        """
+        sequence has the wrong length
+        """
+
+    @unittest.expectedFailure
+    def test_mktime_nonint_types_broken(self):
+        """
+        non integer types that will break
+        """
 
 def struct_time_setup(seq = [1] * 9):
     """
@@ -228,17 +290,14 @@ def struct_time_setup(seq = [1] * 9):
 
     return test_str
 
-def mktime_setup(seq = (1970, 1, 1, 0,0,0,0,0,0) ):
+def mktime_setup(seq):
     """
-    :param seq: a tuple
+    :param seq: a string representation of a sequence
     :return: a test_string to call mktime based on seq
     """
     test_str = adjust("""
-    import time
-    print(">>> st = time.struct_time({seq})")
-    st = time.struct_time({seq})
-    print(">>> time.mktime(st)")
-    print(time.mktime(st))
+    print('''>>> time.mktime({seq})''')
+    print(time.mktime({seq}))
     """).format(seq=seq)
 
     return test_str

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -177,6 +177,17 @@ class TimeTests(TranspileTestCase):
 
         self.assertCodeExecution(adjust(test_str))
 
+    # TESTS FOR MKTIME
+    def test_mktime(self):
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        print('>>> time.mktime((1970, 1, 1, 0,0,0,0,0,0))')
+        print(time.mktime((1970, 1, 1, 0,0,0,0,0,0)))
+        """)
+        self.assertCodeExecution(test_str)
+
 
 def struct_time_setup(seq = [1] * 9):
     """

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -284,6 +284,22 @@ class TimeTests(TranspileTestCase):
         self.assertCodeExecution(test_str)
 
 
+    def test_mktime_overflow_error(self):
+        """
+        tests OverflowError on dates earlier than an arbitrarily defined date
+        for now this is defined as 1900-01-01
+        """
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        """)
+
+        years = (-1970, 70, 1899, 1900, 1901, 2016)
+        sequences = [mktime_setup(str((year,) + (0,) * 8)) for year in years]
+        test_str += ''.join(sequences)
+        self.assertCodeExecution(test_str)
+
 def struct_time_setup(seq = [1] * 9):
     """
     returns a string to set up a struct_time with seq the struct_time constructor

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -348,7 +348,7 @@ class TimeTests(TranspileTestCase):
         bad_years = (-1970, 70, 1899)
 
         for year in bad_years:
-            test_str = set_up + mktime_setup(str((year,) + (0,) * 8))
+            test_str = set_up + mktime_setup(str((year, 1, 1, 0, 0, 0, 0, 0, 0)))
 
             # NOTE: because each example will raise an error, a new VM must be used for each example.
             self.assertJavaScriptExecution(test_str,
@@ -356,7 +356,7 @@ class TimeTests(TranspileTestCase):
                                            run_in_function=False,
                                            out="""
                 >>> import time
-                >>> time.mktime(({}, 0, 0, 0, 0, 0, 0, 0, 0))
+                >>> time.mktime(({}, 1, 1, 0, 0, 0, 0, 0, 0))
                 ### EXCEPTION ###
                 OverflowError: mktime argument out of range
                     test.py:4
@@ -374,25 +374,21 @@ class TimeTests(TranspileTestCase):
         import time
         """)
 
-        seed = [275760, 9, 0, 0, 0, 0, 0, 0, -1]
+        seed = [275760, 9, 0, 0, 0, 0, 0, 0, 1]
 
         for day in range(12, 14):
             seq = seed[:]
             seq[2] = day
             test_str += mktime_setup(str(tuple(seq)))
 
-        # test_str += mktime_setup(str((275760, 9, 13, 0, 0, 0, 0, 0, 0)))
-
-        print(test_str)
-
         self.assertJavaScriptExecution(test_str,
                                        js={},
                                        run_in_function=False,
                                        out="""
         >>> import time
-        >>> time.mktime((275760, 9, 12, 0, 0, 0, 0, 0, -1))
+        >>> time.mktime((275760, 9, 12, 0, 0, 0, 0, 0, 1))
         8639999928000.0
-        >>> time.mktime((275760, 9, 13, 0, 0, 0, 0, 0, -1))
+        >>> time.mktime((275760, 9, 13, 0, 0, 0, 0, 0, 1))
         ### EXCEPTION ###
         OverflowError: signed integer is greater than maximum
             test.py:6
@@ -410,19 +406,19 @@ class TimeTests(TranspileTestCase):
         """)
 
         good_years = (1900, 1970, 2016)
-        sequences = [mktime_setup(str((year,) + (0,) * 8)) for year in good_years]
+        sequences = [mktime_setup(str((year, 1, 1, 0, 0, 0, 0, 0, 0))) for year in good_years]
 
         test_str += ''.join(sequences)
         self.assertJavaScriptExecution(test_str,
                                        js={},
                                        out="""
             >>> import time
-            >>> time.mktime((1900, 0, 0, 0, 0, 0, 0, 0, 0))
-            -2211735600.0
-            >>> time.mktime((1970, 0, 0, 0, 0, 0, 0, 0, 0))
-            -2746800.0
-            >>> time.mktime((2016, 0, 0, 0, 0, 0, 0, 0, 0))
-            1448859600.0
+            >>> time.mktime((1900, 1, 1, 0, 0, 0, 0, 0, 0))
+            -2208970800.0
+            >>> time.mktime((1970, 1, 1, 0, 0, 0, 0, 0, 0))
+            18000
+            >>> time.mktime((2016, 1, 1, 0, 0, 0, 0, 0, 0))
+            1451624400.0
             """)
 
 def struct_time_setup(seq = [1] * 9):

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -1,6 +1,4 @@
 from ..utils import TranspileTestCase, adjust, SAMPLE_DATA
-
-from time import struct_time, mktime
 import unittest
 
 
@@ -180,6 +178,9 @@ class TimeTests(TranspileTestCase):
 
     # TESTS FOR MKTIME
     def test_mktime(self):
+        """
+        tests the happy path for the mktime constructor
+        """
 
         seq = (1970,1,1,0,0,0,0,0,0)
 
@@ -188,21 +189,20 @@ class TimeTests(TranspileTestCase):
         import time
         print('>>> seq = {seq}')
         seq = {seq}
-        print(">>> time.mktime(seq)")
+        print(">>> time.mktime({seq})")
         print(time.mktime(seq))
         #################################
-        print('>>> seq = time.struct_time({seq})')
+        print(">>> seq = time.struct_time({seq})")
         seq = time.struct_time({seq})
         print(">>> time.mktime(seq)")
         print(time.mktime(seq))
-        """).format(seq=seq)
+        """).format(seq=str(seq))
 
         self.assertCodeExecution(test_str)
 
     def test_mktime_bad_input(self):
         """
-        when the argument passed is not tuple or struct_time. This error is thrown
-        expected error TypeError: Tuple or struct_time argument required
+        When the argument passed is not tuple or struct_time.
         """
 
         seed = (1970,1,1,0,0,0,0,0,0)
@@ -233,46 +233,56 @@ class TimeTests(TranspileTestCase):
 
         self.assertCodeExecution(test_str)
 
-    # def test_mktime_overflow(self):
-    #     """
-    #     argument is too small or large and throws this error:
-    #     OverflowError: mktime argument out of range
-    #
-    #     :return:
-    #     """
-    #
-    #     test_str = adjust("""
-    #     print('>>> import time')
-    #     import time
-    #     """)
-    #
-    #     sequences = [
-    #         (1901, 12, 13, 0, 0, 0, 0, 0, 0),
-    #
-    #     ]
-
     def test_mktime_non_integer_types(self):
         """
-        tests behavior when non integer types are part of the sequence passed
+        Tests behavior when non integer types are part of the sequence passed
         """
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        """)
 
         strange_types = [ SAMPLE_DATA[type][0] for type in SAMPLE_DATA if type != 'int' ]
 
         tests = [ mktime_setup( str((1970, t, 1, 2, 0, 0, 0, 0, 0)) ) for t in strange_types]
-        test_str = ''.join(tests)
+        test_str += ''.join(tests)
 
         self.assertCodeExecution(test_str)
 
     def test_mktime_seq_wrong_length(self):
         """
-        sequence has the wrong length
+        Sequence has the wrong length
         """
 
-    @unittest.expectedFailure
-    def test_mktime_nonint_types_broken(self):
+        seq = (1970,1,1,0,0,0,0,0)  # length=8
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        """)
+
+        test_str += mktime_setup(seq)
+        print(test_str)
+        self.assertCodeExecution(test_str)
+
+    def test_mktime_wrong_arg_count(self):
         """
-        non integer types that will break
+        Called with the wrong number of args
         """
+
+        test_str = adjust("""
+        print('>>> import time')
+        import time
+        print('>>> time.mktime()')
+        print(time.mktime())
+        ############################
+        print('>>> time.mktime(1,2)')
+        print(time.mktime(1,2))
+        """)
+
+        self.assertCodeExecution(test_str)
+
 
 def struct_time_setup(seq = [1] * 9):
     """

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -1,5 +1,6 @@
-from ..utils import TranspileTestCase, adjust
+from ..utils import TranspileTestCase, adjust, SAMPLE_DATA
 
+from time import struct_time, mktime
 import unittest
 
 
@@ -181,6 +182,35 @@ class TimeTests(TranspileTestCase):
     def test_mktime(self):
         self.assertCodeExecution(mktime_setup())
 
+    def test_mktime_bad_input(self):
+        """
+        TypeError: Tuple or struct_time argument required
+        """
+
+        bad_types=[
+
+
+        ]
+
+
+    def test_mktime_non_integer_types(self):
+
+        strange_types = [
+            True,
+            bytearray
+
+        ]
+
+        tests = [ mktime_setup( (1970, t, 1, 2, 0, 0, 0, 0, 0) ) for t in strange_types]
+        test_str = ''.join(tests)
+
+        self.assertCodeExecution(test_str)
+        # seq = (1970, .5, 1,2,0,0,0,0,0)
+        # st = struct_time(seq)
+        # test_str = mktime_setup(seq)
+        # self.assertCodeExecution(test_str)
+
+    def
 
 def struct_time_setup(seq = [1] * 9):
     """
@@ -198,17 +228,17 @@ def struct_time_setup(seq = [1] * 9):
 
     return test_str
 
-def mktime_setup(seq = struct_time(1970, 1, 1, 0,0,0,0,0,0)):
+def mktime_setup(seq = (1970, 1, 1, 0,0,0,0,0,0) ):
     """
-    :param seq: a struct_time instance
-    :return: a test_string to call mktime from a struct_time instance
+    :param seq: a tuple
+    :return: a test_string to call mktime based on seq
     """
-
     test_str = adjust("""
+    import time
     print(">>> st = time.struct_time({seq})")
     st = time.struct_time({seq})
-    print(">>> time.mktime({seq})")
-    print(time.mktime({seq}))
+    print(">>> time.mktime(st)")
+    print(time.mktime(st))
     """).format(seq=seq)
-    #
-    # return test_str
+
+    return test_str

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -283,11 +283,13 @@ class TimeTests(TranspileTestCase):
 
         self.assertCodeExecution(test_str)
 
-
+    @unittest.expectedFailure
     def test_mktime_overflow_error(self):
         """
         tests OverflowError on dates earlier than an arbitrarily defined date
         for now this is defined as 1900-01-01
+
+        currently this can't be garuneteed to pass because it doesn't not account for behavior across platforms.
         """
 
         test_str = adjust("""

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -1,3 +1,4 @@
+from time import gmtime, localtime
 from ..utils import TranspileTestCase, adjust, SAMPLE_DATA
 import unittest
 
@@ -369,16 +370,18 @@ class TimeTests(TranspileTestCase):
         source: http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.1
         """
 
-        seed = [275760, 9, 0, 0, 0, 0, 0, 0, 1]
+        hour = 24 + localtime().tm_hour - gmtime().tm_hour
+
+        seed = [275760, 9, 12, hour, 0, 0, 0, 0, 1] # the max date that can be computed.
         set_up = adjust("""
         print('>>> import time')
         import time
         """)
 
-        for day in range(12, 14):
+        for second in range(0, 2):
             seq = seed[:]
-            seq[2] = day
-            same = day == 13 # do we expect the JS output to be equal?
+            seq[5] = second
+            same = second == 1 # do we expect an error?
             test_str = set_up + mktime_setup(str(tuple(seq)))
 
             # need to compare each example individually
@@ -388,11 +391,11 @@ class TimeTests(TranspileTestCase):
                                            same=same,
                                            out="""
             >>> import time
-            >>> time.mktime((275760, 9, {}, 0, 0, 0, 0, 0, 1))
+            >>> time.mktime((275760, 9, 12, {hour}, 0, {second}, 0, 0, 1))
             ### EXCEPTION ###
             OverflowError: signed integer is greater than maximum
                 test.py:4
-            """.format(day))
+            """.format(hour=hour, second=second))
 
 
     def test_mktime_no_overflow_error(self):

--- a/tests/modules/test_time.py
+++ b/tests/modules/test_time.py
@@ -179,14 +179,7 @@ class TimeTests(TranspileTestCase):
 
     # TESTS FOR MKTIME
     def test_mktime(self):
-
-        test_str = adjust("""
-        print('>>> import time')
-        import time
-        print('>>> time.mktime((1970, 1, 1, 0,0,0,0,0,0))')
-        print(time.mktime((1970, 1, 1, 0,0,0,0,0,0)))
-        """)
-        self.assertCodeExecution(test_str)
+        self.assertCodeExecution(mktime_setup())
 
 
 def struct_time_setup(seq = [1] * 9):
@@ -204,3 +197,18 @@ def struct_time_setup(seq = [1] * 9):
     """).format(type_name=type(seq), seq=seq)
 
     return test_str
+
+def mktime_setup(seq = struct_time(1970, 1, 1, 0,0,0,0,0,0)):
+    """
+    :param seq: a struct_time instance
+    :return: a test_string to call mktime from a struct_time instance
+    """
+
+    test_str = adjust("""
+    print(">>> st = time.struct_time({seq})")
+    st = time.struct_time({seq})
+    print(">>> time.mktime({seq})")
+    print(time.mktime({seq}))
+    """).format(seq=seq)
+    #
+    # return test_str

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -553,7 +553,7 @@ class TranspileTestCase(TestCase):
             self, code, out,
             extra_code=None, js=None,
             run_in_global=True, run_in_function=True,
-            args=None, substitutions=None):
+            args=None, substitutions=None, same=True):
         "Run code under JavaScript and check the output is as expected"
         self.maxDiff = None
         #==================================================
@@ -599,8 +599,11 @@ class TranspileTestCase(TestCase):
             # normalized format for exceptions, floats etc.
             js_out = cleanse_javascript(js_out, substitutions)
 
-            # Confirm that the output of the JavaScript code is the same as the Python code.
-            self.assertEqual(js_out, py_out, 'Global context')
+            # Compare the output of the JavaScript code with the Python code.
+            if same:
+                self.assertEqual(js_out, py_out, 'Global context')
+            else:
+                self.assertNotEqual(js_out, py_out, 'Global context')
 
         #==================================================
         # Pass 2 - run the code in a function's context
@@ -638,8 +641,11 @@ class TranspileTestCase(TestCase):
             # normalized format for exceptions, floats etc.
             js_out = cleanse_javascript(js_out, substitutions)
 
-            # Confirm that the output of the JavaScript code is the same as the Python code.
-            self.assertEqual(js_out, py_out, 'Function context')
+            # Compare the output of the JavaScript code with the Python code.
+            if same:
+                self.assertEqual(js_out, py_out, 'Function context')
+            else:
+                self.assertNotEqual(js_out, py_out, 'Function context')
 
 
 class NotImplementedToExpectedFailure:


### PR DESCRIPTION
Here is a first stab at `time.mktime`. I welcome input on how to make it complete. One thing I'm not sure to do is how to handle a two digit year

While Python will interpret a two digit year literally, phantomjs interprets a 2 digit year as being in the 20th century not the first. Example:
```
phantomjs> new Date(70, 01, 01, 0, 0, 0, 0, 0).getTime()
2696400000
phantomjs> new Date(1970, 01, 01, 0, 0, 0, 0, 0).getTime()
2696400000     //wat
```
If handed a 2 digit year, should the function assume its in the 20th century, throw some kind of error or do something else?