### PR TITLE
Add information about setting up Python 3.4

### DIFF
--- a/docs/internals/contributing.rst
+++ b/docs/internals/contributing.rst
@@ -17,7 +17,7 @@ instead of using the official PyBee repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python 3.4, and have virtualenv available for use.
+have `Python 3.4 </intro/localpython>`_, and have virtualenv available for use.
 
 Start by forking Batavia into your own Github repository; then
 check out your fork to your own computer into a development directory:

--- a/docs/intro/getting-started.rst
+++ b/docs/intro/getting-started.rst
@@ -2,7 +2,7 @@ Getting Started
 ===============
 
 In this guide we will walk you through setting up your Batavia environment for
-development and testing. We will assume that you have a working Python 3.4,
+development and testing. We will assume that you have a `working Python 3.4 </intro/localpython.rst>`_,
 and use virtualenv.
 
 Get a copy of Batavia

--- a/docs/intro/localpython.rst
+++ b/docs/intro/localpython.rst
@@ -1,0 +1,16 @@
+Installing Python 3.4 locally
+=============================
+
+Batavia relies on a very specific version of Python to operate. 
+
+If you don't have Python 3.4, you can use `pyenv <https://github.com/yyuu/pyenv>`_
+ to install it along any other version of python on your system. Once installed,
+you will need to set 3.4.4 to be the version to use locally, and install virtualenv
+ within this environment before continuing.
+
+.. code-block:: bash
+
+    $ pyenv local 3.4.4
+    $ pip install virtualenv
+
+From here, the processes described in the tutorials will be able to be followed. 


### PR DESCRIPTION
I'm not 100% happy with this as is. `pyenv` works in OSX fine, but I'm not sure how it fares in other environments, and I don't want to be making recommendations that don't work in all environments. 

