### PR TITLE
Turn off unnecessary memory hog services in CircleCI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,11 @@ dependencies:
     - test -e ouroboros || git clone https://github.com/pybee/ouroboros.git
 
 test:
+  pre:
+    - sudo service couchdb stop || true
+    - sudo service mongod stop || true
+    - sudo service mysql stop || true
+    - sudo service postgresql stop || true
   override:
      - python setup.py test:
          timeout: 60


### PR DESCRIPTION
These services are unnecessary for our test setup, and they consume more memory than our Python tests by quite a margin.

This should help with some of the other PRs that increase memory usage of our test scripts.