### PR TITLE
Recommend the use of Cricket for running Batavia's test suite

### DIFF
--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -206,26 +206,49 @@ To check that PhantomJS is working, run the following:
 Running the test suite
 ----------------------
 
-You're now ready to run the test suite! In the ``batavia-dev/batavia`` directory, type:
+You're now ready to run the test suite! This can be done the
+immediately-available-but-tiresome way, or the takes-little-effort-but-then-fun
+way, which is preferred.
+
+For the fun way, you need to install BeeWare's test-running tool,
+Cricket_. Follow the installation instructions to install it into your
+virtualenv; then, in the ``batavia-dev/batavia`` directory, type:
+
+.. _Cricket: https://cricket.readthedocs.io/en/latest/
+
+.. code-block:: bash
+
+    $ cricket-unittest
+
+This launches a test-running GUI, where you can easily and intuitively
+run all tests or a subset of tests, see the progress of tests (which is
+quite valuable when running over 10000 tests), and whenever failure is
+encountered, immediately see the details.
+
+If, for whatever reason, you want to run the tests without Cricket, you can
+always use a text test runner by typing:
 
 .. code-block:: bash
 
     $ python setup.py test
 
-This will take at least 20 minutes, and can take upwards of 1.5hrs, on most modern PCs/laptops,
-and will generate around 10000 lines of console output - one line for each test that is executed.
-Each line will tell you the pass/fail status of each test - e.g.,::
+This will take at least several minutes, and can take upwards of 1.5hrs on most
+modern PCs/laptops. It will also generate around 10000 lines of console output -
+one line for each test that is executed.  Each line will tell you the pass/fail
+status of each test - e.g.,::
 
     test_abs_not_implemented (tests.builtins.test_abs.AbsTests) ... expected failure
     test_bool (tests.builtins.test_abs.BuiltinAbsFunctionTests) ... ok
 
 This indicates that tests have passed (``ok``), or have failed in an expected
-way (``expected failure``). These outcomes are what you expect to see. If you
-see any lines that end ``FAIL``, ``ERROR``, or ``unexpected success``, then
-you've found a problem. If this happens, at the end of the test run, you’ll
+way (``expected failure``). These outcomes are what you expect to see.
+
+If you see any tests reported as ``FAIL``, ``ERROR``, or ``unexpected success``,
+then you've found a problem. If this happens, at the end of the test run, you’ll
 also see a summary of the cause of those problems.
 
-If you see "ERROR" press ctrl-c or cmd-c to quit the tests, and then start debugging.
+As soon as you see problems, you can stop the tests and start debugging. Cricket
+has a button for this; with the text test runner, hit Ctrl-C or Cmd-C to quit.
 
 However, this *shouldn't* happen - Batavia runs `continuous integration`_ to
 make sure the test suite is always in a passing state. If you *do* get any
@@ -235,7 +258,7 @@ may have found a problem.
 
 .. _continuous integration: https://travis-ci.org/pybee/batavia
 
-If you just want to run a single test, or a single group of tests, you can provide command-line arguments.
+If you just want to run a single test, or a single group of tests with the text runner, you can provide command-line arguments.
 
 To run a single test, provide the full dotted-path to the test:
 


### PR DESCRIPTION
Cricket is a much better way to run large test suites like Batavia's