### PR TITLE
Add support for Python 3.5.3, step 1

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1363,6 +1363,7 @@ batavia.VirtualMachine.prototype.byte_BUILD_SET = function(count) {
 batavia.VirtualMachine.prototype.byte_BUILD_MAP = function(size) {
     switch (batavia.BATAVIA_MAGIC) {
         case batavia.BATAVIA_MAGIC_35:
+        case batavia.BATAVIA_MAGIC_353:
             var items = this.popn(size * 2);
             var dict = new batavia.types.Dict();
 
@@ -1382,7 +1383,7 @@ batavia.VirtualMachine.prototype.byte_BUILD_MAP = function(size) {
 
         default:
             throw new batavia.builtins.BataviaError(
-                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python versionStrange"
+                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python version (supported: 3.4, 3.5)"
             );
     }
 };
@@ -1390,6 +1391,7 @@ batavia.VirtualMachine.prototype.byte_BUILD_MAP = function(size) {
 batavia.VirtualMachine.prototype.byte_STORE_MAP = function() {
     switch (batavia.BATAVIA_MAGIC) {
         case batavia.BATAVIA_MAGIC_35:
+        case batavia.BATAVIA_MAGIC_353:
             throw new batavia.builtins.BataviaError(
                 "STORE_MAP is unsupported with BATAVIA_MAGIC"
             );
@@ -1408,7 +1410,7 @@ batavia.VirtualMachine.prototype.byte_STORE_MAP = function() {
 
         default:
             throw new batavia.builtins.BataviaError(
-                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python versionStrange"
+                "Unsupported BATAVIA_MAGIC. Possibly using unsupported Python version (supported: 3.4, 3.5)"
             );
     }
 };

--- a/batavia/batavia.js
+++ b/batavia/batavia.js
@@ -16,4 +16,5 @@ var batavia = {
 batavia.BATAVIA_MAGIC = null;
 batavia.BATAVIA_MAGIC_34 = String.fromCharCode(238, 12, 13, 10);
 batavia.BATAVIA_MAGIC_35 = String.fromCharCode(22, 13, 13, 10);
+batavia.BATAVIA_MAGIC_353 = String.fromCharCode(23, 13, 13, 10);
 batavia.BATAVIA_MAGIC_35a0 = String.fromCharCode(248, 12, 13, 10);


### PR DESCRIPTION
This adds and uses the BATAVIA_MAGIC required for Python 3.5.3
(or Python 3.5.2+ on Debian and Ubuntu).

This still leaves 17 failing tests, because of actual changes between
3.5.2 and 3.5.3, so it does not solve Github issue #383.