### PR TITLE
Replace Travis CI status badge with CircleCI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ Batavia
 .. image:: https://img.shields.io/pypi/l/batavia.svg
     :target: https://github.com/pybee/batavia/blob/master/LICENSE
 
-.. image:: https://travis-ci.org/pybee/batavia.svg?branch=master
-    :target: https://travis-ci.org/pybee/batavia
+.. image:: https://circleci.com/gh/pybee/batavia.svg?style=shield&circle-token=:circle-token
+    :target: https://circleci.com/gh/pybee/batavia
 
 .. image:: https://badges.gitter.im/pybee/general.svg
     :target: https://gitter.im/pybee/general


### PR DESCRIPTION
Currently the README says tests pass, but it's sourcing that information from Travis, which was last used 4 months ago >_<