### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Documentation
 Contributing
 ------------
 
-If you'd like to contribute to Batavia development, our `guide for first time contributors <http://batavia.readthedocs.io/en/latest/internals/contributing.html>`_ will help you get started.
+If you'd like to contribute to Batavia development, our `guide for first time contributors <http://pybee.org/contributing/first-time/what/batavia/>`_ will help you get started.
 
 If you experience problems with Batavia, `log them on GitHub <https://github.com/pybee/batavia/issues>`_.
 


### PR DESCRIPTION
I was looking into contributing for the project when I realized that the README file had a broken link for the document page. The image of the page is attached. 

I changed it to the contributions page from the Pybee page. The project internals link also leads to the same page and that needs to be changed as well but I don't know what should be the page for that link. 

![2016-12-23-230737_1366x768_scrot](https://cloud.githubusercontent.com/assets/21151744/21452145/b171fcf6-c969-11e6-9ae9-18fbbc1b4c9c.png)
