### PR TITLE
Updated installation instruction for linux and mac

### DIFF
--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -25,6 +25,8 @@ how to set this up are `on our Environment setup guide
    $ . venv/bin/activate
    $ cd batavia
    $ pip install -e .
+   On running last command it might throw an error, then run::   
+      $pip install -e PathOfTheDirectoryInWhichBataviaIsCloned
 
  * For Windows::
 


### PR DESCRIPTION
My terminal was throwing an error after running only::
    pip install -e
and was asking me to mention the directory path explicitly.
Here is the link: http://picpaste.com/Screenshot_from_2016-12-27_11-34-48-l5vay0h8.png
So,added line 28 and 29.