### PR TITLE
Accept and use commandline arguments to locate Ouroboros

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   pre:
     - sudo apt-get install pandoc
   override:
-    - sudo npm install -g npm
+    - npm install -g npm
     - npm install
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
   pre:
     - sudo apt-get install pandoc
   override:
+    - npm install npm
     - npm install
 
 test:
@@ -19,7 +20,6 @@ test:
     - sudo service mysql stop || true
     - sudo service postgresql stop || true
   override:
-    - npm install install
     - "pip install pytest":
         parallel: true
     - "pip install git+https://github.com/pybee/pytest-circleci":

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   pre:
     - sudo apt-get install pandoc
   override:
-    - npm install npm
+    - sudo npm install -g npm
     - npm install
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ test:
     - sudo service mysql stop || true
     - sudo service postgresql stop || true
   override:
+    - npm install install
     - "pip install pytest":
         parallel: true
     - "pip install git+https://github.com/pybee/pytest-circleci":

--- a/compile_stdlib.py
+++ b/compile_stdlib.py
@@ -37,7 +37,9 @@ def parse_args():
     ]
 
     # find the ouroboros directory
-    if os.path.exists('./node_modules/ouroboros'):
+    if args.source and os.path.exists(args.source):
+        ouroboros = args.source
+    elif os.path.exists('./node_modules/ouroboros'):
         ouroboros = './node_modules/ouroboros'
     else:
         exit("Please install the development dependencies with `npm install`.")

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "python compile_stdlib.py && pandoc --from=rst --to=markdown_github README.rst -o README.md",
+    "prepare": "python compile_stdlib.py $* && pandoc --from=rst --to=markdown_github README.rst -o README.md",
     "build": "node_modules/.bin/webpack --progress",
     "watch": "node_modules/.bin/webpack --progress --watch",
     "serve": "node_modules/.bin/webpack-dev-server --inline --hot --port 3000"


### PR DESCRIPTION
The `--source` argument was added to `compile_stdlib.py` but wasn't yet used to locate Ouroboros' source files.

In addition to that, `npm install` wasn't able to accept or use any commandline arguments for the source location of Ouroboros, so even if you provided it to `python compile_stdlib.py`, it wouldn't be reflected when you used `npm install`.

This PR also contains a change in `package.json` turning `prepublish` into `prepare` as `prepublish` isn't run for local, dev-style installs as of `npm` 4ish. If skipping this is the desired procedure (seems to make tests impossible to run), I'll happily revert.