### PR TITLE
ignoring tmp directories created by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ distribute-*
 /batavia/stdlib.js
 /batavia/stdlib/*.js
 /tests/temp
+/tests/tmp*
 env
 .eggs/
 .python-version


### PR DESCRIPTION
the test suite add extra directories. Should they be `.gitignore`d?