### PR TITLE
Sanitize bool

### DIFF
--- a/batavia/builtins/bool.js
+++ b/batavia/builtins/bool.js
@@ -31,7 +31,7 @@ function bool(args, kwargs) {
     // Python bool() checks for __bool__ and then, if __bool__ is not defined,
     // for __len__. See https://docs.python.org/3.4/library/stdtypes.html#truth.
     } else if (args[0].__len__) {
-        var output = callables.call_method(args[0], '__len__', [])
+        output = callables.call_method(args[0], '__len__', [])
         var output_type = type_name(output)
 
         if (output_type === 'int') {
@@ -39,9 +39,8 @@ function bool(args, kwargs) {
             // even if the output type is int and the value __len__ appears to
             // output in the browser is an integer.
             return !!parseInt(output.valueOf())
-
         } else {
-            throw new exceptions.TypeError.$pyclass("'" + output_type + "' object cannot be interpreted as an integer")                
+            throw new exceptions.TypeError.$pyclass("'" + output_type + "' object cannot be interpreted as an integer")
         }
     } else {
         return new types.Bool((!!args[0].valueOf()))

--- a/batavia/builtins/bool.js
+++ b/batavia/builtins/bool.js
@@ -1,5 +1,6 @@
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
+var type_name = require('../core').type_name
 var types = require('../types')
 
 function bool(args, kwargs) {
@@ -21,13 +22,27 @@ function bool(args, kwargs) {
         // args[0].__bool__, if it exists, is a batavia.types.Function.js,
         // *not* a native Javascript function. Therefore we can't call it in
         // the seemingly obvious way, with __bool__().
-        return callables.call_method(args[0], '__bool__', [])
+        var output = callables.call_method(args[0], '__bool__', [])
+        if ((output === true) || (output === false)) {
+            return output
+        } else {
+            throw new exceptions.TypeError.$pyclass('__bool__ should return bool, returned ' + type_name(output))
+        }
     // Python bool() checks for __bool__ and then, if __bool__ is not defined,
     // for __len__. See https://docs.python.org/3.4/library/stdtypes.html#truth.
     } else if (args[0].__len__) {
-        // valueOf() can return a string even when __len__ was set to an
-        // integer (as in builtins.test_bool.BoolTests.test_len_only).
-        return !!parseInt(callables.call_method(args[0], '__len__', []).valueOf())
+        var output = callables.call_method(args[0], '__len__', [])
+        var output_type = type_name(output)
+
+        if (output_type === 'int') {
+            // Yes, the value under the hood can have been cast to string
+            // even if the output type is int and the value __len__ appears to
+            // output in the browser is an integer.
+            return !!parseInt(output.valueOf())
+
+        } else {
+            throw new exceptions.TypeError.$pyclass("'" + output_type + "' object cannot be interpreted as an integer")                
+        }
     } else {
         return new types.Bool((!!args[0].valueOf()))
     }

--- a/batavia/builtins/bool.js
+++ b/batavia/builtins/bool.js
@@ -23,7 +23,7 @@ function bool(args, kwargs) {
         // *not* a native Javascript function. Therefore we can't call it in
         // the seemingly obvious way, with __bool__().
         var output = callables.call_method(args[0], '__bool__', [])
-        if (type_name(output) === 'bool') {
+        if (types.isinstance(output, types.Bool)) {
             return output
         } else {
             throw new exceptions.TypeError.$pyclass('__bool__ should return bool, returned ' + type_name(output))
@@ -34,7 +34,7 @@ function bool(args, kwargs) {
         output = callables.call_method(args[0], '__len__', [])
         var output_type = type_name(output)
 
-        if (output_type === 'int') {
+        if (types.isinstance(output, types.Int)) {
             // Yes, the value under the hood can have been cast to string
             // even if the output type is int and the value __len__ appears to
             // output in the browser is an integer.

--- a/batavia/builtins/bool.js
+++ b/batavia/builtins/bool.js
@@ -23,7 +23,7 @@ function bool(args, kwargs) {
         // *not* a native Javascript function. Therefore we can't call it in
         // the seemingly obvious way, with __bool__().
         var output = callables.call_method(args[0], '__bool__', [])
-        if ((output === true) || (output === false)) {
+        if (type_name(output) === 'bool') {
             return output
         } else {
             throw new exceptions.TypeError.$pyclass('__bool__ should return bool, returned ' + type_name(output))

--- a/tests/builtins/test_bool.py
+++ b/tests/builtins/test_bool.py
@@ -58,6 +58,7 @@ class BoolTests(TranspileTestCase):
         print(bool(BoolHate("zero")))
         print(bool(BoolHate([1, 2, 3])))
         print(bool(BoolHate({1: 2})))
+        print(bool(BoolHate(1.2)))
         """)
 
     def test_len_malicious(self):
@@ -72,6 +73,7 @@ class BoolTests(TranspileTestCase):
         print(bool(LenHate("zero")))
         print(bool(LenHate([1, 2, 3])))
         print(bool(LenHate({1: 2})))
+        print(bool(LenHate(1.2)))
         """)
 
 class BuiltinBoolFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_bool.py
+++ b/tests/builtins/test_bool.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 import unittest
@@ -48,32 +49,34 @@ class BoolTests(TranspileTestCase):
 
     def test_bool_malicious(self):
         self.assertCodeExecution("""
-        class BoolHate:
-            def __init__(self, val):
-                self.val = val
+            class BoolHate:
+                def __init__(self, val):
+                    self.val = val
 
-            def __bool__(self):
-                return self.val
+                def __bool__(self):
+                    return self.val
 
-        print(bool(BoolHate("zero")))
-        print(bool(BoolHate([1, 2, 3])))
-        print(bool(BoolHate({1: 2})))
-        print(bool(BoolHate(1.2)))
+            print(bool(BoolHate("zero")))
+            print(bool(BoolHate([1, 2, 3])))
+            print(bool(BoolHate({1: 2})))
+            print(bool(BoolHate(1.2)))
+            print(bool(BoolHate("👿")))
         """)
 
     def test_len_malicious(self):
         self.assertCodeExecution("""
-        class LenHate:
-            def __init__(self, val):
-                self.val = val
+            class LenHate:
+                def __init__(self, val):
+                    self.val = val
 
-            def __len__(self):
-                return self.val
+                def __len__(self):
+                    return self.val
 
-        print(bool(LenHate("zero")))
-        print(bool(LenHate([1, 2, 3])))
-        print(bool(LenHate({1: 2})))
-        print(bool(LenHate(1.2)))
+            print(bool(LenHate("zero")))
+            print(bool(LenHate([1, 2, 3])))
+            print(bool(LenHate({1: 2})))
+            print(bool(LenHate(1.2)))
+            print(bool(BoolHate("👿")))
         """)
 
 class BuiltinBoolFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_bool.py
+++ b/tests/builtins/test_bool.py
@@ -46,6 +46,33 @@ class BoolTests(TranspileTestCase):
             print(bool(NoLenNoBool(-2)))
             """)
 
+    def test_bool_malicious(self):
+        self.assertCodeExecution("""
+        class BoolHate:
+            def __init__(self, val):
+                self.val = val
+
+            def __bool__(self):
+                return self.val
+
+        print(bool(BoolHate("zero")))
+        print(bool(BoolHate([1, 2, 3])))
+        print(bool(BoolHate({1: 2})))
+        """)
+
+    def test_len_malicious(self):
+        self.assertCodeExecution("""
+        class LenHate:
+            def __init__(self, val):
+                self.val = val
+
+            def __len__(self):
+                return self.val
+
+        print(bool(LenHate("zero")))
+        print(bool(LenHate([1, 2, 3])))
+        print(bool(LenHate({1: 2})))
+        """)
 
 class BuiltinBoolFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["bool"]


### PR DESCRIPTION
In #448 the question arose of how to handle malicious output from `__bool__` or `__len__`. Now we handle it! (Sadly, no emoji; tests barfed badly when I tried to `print(bool(BoolHate(`👿`)))`.