### PR TITLE
Implement built-in function `next`

### DIFF
--- a/batavia/builtins/next.js
+++ b/batavia/builtins/next.js
@@ -1,9 +1,36 @@
 var exceptions = require('../core').exceptions
+var callables = require('../core').callables
+var type_name = require('../core').type_name
 
 function next(args, kwargs) {
     // if its iterable return next thing in iterable
     // else stop iteration
-    throw new exceptions.NotImplementedError.$pyclass("Builtin Batavia function 'next' not implemented")
+    if (arguments.length !== 2) {
+        throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
+    }
+    if (kwargs && Object.keys(kwargs).length > 0) {
+        throw new exceptions.TypeError.$pyclass('next() takes no keyword arguments')
+    }
+    if (!args || args.length === 0) {
+        throw new exceptions.TypeError.$pyclass('next expected at least 1 arguments, got 0')
+    }
+    if (args.length > 2) {
+        throw new exceptions.TypeError.$pyclass('next expected at most 2 arguments, got ' + args.length)
+    }
+
+    try {
+        return callables.call_method(args[0], '__next__', [])
+    } catch (e) {
+        if (e instanceof exceptions.StopIteration.$pyclass) {
+            if (args.length === 2) {
+                return args[1]
+            } else {
+                throw e
+            }
+        } else {
+            throw new exceptions.TypeError.$pyclass("'" + type_name(args[0]) + "' object is not an iterator")
+        }
+    }
 }
 next.__doc__ = 'next(iterator[, default])\n\nReturn the next item from the iterator. If default is given and the iterator\nis exhausted, it is returned instead of raising StopIteration.'
 

--- a/tests/builtins/test_next.py
+++ b/tests/builtins/test_next.py
@@ -4,21 +4,19 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class NextTests(TranspileTestCase):
-    @expectedFailure
+
     def test_next_success(self):
         self.assertCodeExecution("""
             i = iter([1])
             print(next(i))
         """)
 
-    @expectedFailure
     def test_next_success_with_default(self):
         self.assertCodeExecution("""
             i = iter([1])
             print(next(i, 0))
         """)
 
-    @expectedFailure
     def test_next_exhausted_with_default(self):
         self.assertCodeExecution("""
             i = iter([])
@@ -37,22 +35,6 @@ class BuiltinNextFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["next"]
 
     not_implemented = [
-        'test_noargs',
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
         'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
         'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
     ]


### PR DESCRIPTION
This is in regard to https://github.com/pybee/batavia/issues/47
`next` implemented by trying to call `__next__` method of passed object.
3 test cases still marked as expect to fail:
Two test cases (`test_set` and `test_frozenset`) fail due to existing bug with `__next__` https://github.com/pybee/batavia/issues/467
One test case (`test_next_exhausted_without_default`) fails because of https://github.com/pybee/batavia/issues/468