### PR TITLE
Remove erroneous test case

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -795,7 +795,6 @@ SAMPLE_DATA = {
     'set': [
             'set()',
             '{1, 2.3456, "another"}',
-            '{{1, 2}, {1, 2}}',
         ],
     'slice': [
             'slice(0)',


### PR DESCRIPTION
The faulty test case tries to create set of sets which is invalid in
Python (set can only contain hashable elements)