### PR TITLE
Fix broken link in docs/intro/tutorial-0.rst

### DIFF
--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -6,7 +6,7 @@ the Batavia code, and the ouroboros dependency within a virtual environment.
 
 You'll need to have Python 3.4 available for Batavia to work. Instructions on
 how to set this up are `on our Environment setup guide
-<http://pybee.org/contributing/first-time/setup/>`_.
+<http://pybee.org/contributing/how/first-time/setup/>`_.
 
 1. Setup a `pybee` folder to store everything::
 


### PR DESCRIPTION
Close #474 

batavia/docs/intro/tutorial-0.rst
https://batavia.readthedocs.io/en/latest/intro/tutorial-0.html

The "on our Environment setup guide" link leads to http://pybee.org/contributing/first-time/setup/ which does not exist.
Instead, it now leads to http://pybee.org/contributing/how/first-time/setup/