### PR TITLE
Allow `raise <type>` form of raise

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1681,6 +1681,10 @@ VirtualMachine.prototype.do_raise = function(exc, cause) {
         // As in `throw ValueError('foo')`
         exc_type = exc.__class__
         val = exc
+    } else if (exc.$pyclass.prototype instanceof builtins.BaseException.$pyclass ||
+               exc.$pyclass === builtins.BaseException.$pyclass) {
+        exc_type = exc
+        val = new exc_type.$pyclass()
     } else {
         return 'exception'  // error
     }

--- a/tests/structures/test_exception.py
+++ b/tests/structures/test_exception.py
@@ -16,3 +16,11 @@ class ExceptionTests(TranspileTestCase):
                 print("Got a Key Error")
             print('Done.')
             """)
+
+    def test_raise_class(self):
+        self.assertCodeExecution("""
+            try:
+                raise Exception
+            except Exception as err:
+                print(err)
+        """)


### PR DESCRIPTION
Before only `raise` or `raise <instance>` e.g. raise Exception() was
supported and attempts to call `raise <type>` e.g. raise Exception
would result in unhandled Batavia Error.

https://github.com/python/cpython/blob/3.4/Python/ceval.c#L3698 see here for CPython 3.4 implementation