### PR TITLE
Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,8 +38,9 @@ Prerequisites
 Batavia requires a Python 3.4 or Python 3.5 installation, and a virtualenv to
 run it all in.  Python 3.6 is not yet supported.
 
-You also need to have a recent install of `Node.js <https://nodejs.org>`_. If
-your version of Node is outdated, you can update it using the command::
+You also need to have a recent install of `Node.js <https://nodejs.org>`_
+(from the “stable” 6.X series), and a current version of npm. If
+your version of npm is outdated, you can update it using the command::
 
    $ npm install npm@latest -g
 
@@ -58,19 +59,24 @@ Downloading and Installing
 
 2. Setup a virtualenv (for other environments, see `Getting Started <https://batavia.readthedocs.io/en/latest/intro/tutorial-0.html>`_).
 
-Linux/Unix/Mac::
+  Linux/Unix/Mac:
 
-   $ virtualenv --python=$(which python3) venv
-   $ . venv/bin/activate
-   $ cd batavia
-   $ pip install -e .
+  Check your python3 version first.  If it's pointing to version 3.6, replace
+  ``$(which python3)`` in the virtualenv command below with the path to your
+  Python 3.4 or 3.5 installation::
 
-Windows::
+    $ python3 --version
+    $ virtualenv --python=$(which python3) venv
+    $ . venv/bin/activate
+    $ cd batavia
+    $ pip install -e .
 
-   > virtualenv venv
-   > venv\Scripts\activate
-   > cd batavia
-   > pip install -e .
+  Windows::
+
+     > virtualenv venv
+     > venv\Scripts\activate
+     > cd batavia
+     > pip install -e .
 
 3. Install `Node.js <https://nodejs.org>`_. You must have a recent version of
    Node; we do our testing using v6.9.1. Once you've installed Node, you can


### PR DESCRIPTION
This adds a few minor edits and clarifications in the README.

- Specify that you need version 6.X of Node, and not the latest V7.X (this is in the Getting Started tutorial, but the README just said you needed a recent install of Node)
- Correct the instruction for updating npm to refer to npm and not Node
- Indent the environment sections under Downloading and Installing # 2 to make it clearer that # 3 is a new instruction and not part of the previous # 2
- Add an instruction to check which version `python3` is pointing to and make sure the virtualenv isn't created with (unsupported) Python 3.6 

Signed-off-by: Becky Smith <rebkwok@gmail.com>
