### PR TITLE
Enabling test test_kwargs_missing_key in test_str.py

### DIFF
--- a/batavia/types/StrUtils.js
+++ b/batavia/types/StrUtils.js
@@ -662,8 +662,6 @@ function _substitute(format, args) {
                 if (err.msg === 'illegal character') {
                     var charAsHex = nextChar.charCodeAt(0).toString(16)
                     throw new exceptions.ValueError.$pyclass(`unsupported format character '${nextChar}' (0x${charAsHex}) at index ${charIndex + index + 1}`)
-                } else if (err.name === 'KeyError') {
-                    throw new exceptions.KeyError.$pyclass(err.msg)
                 } else {
                   // its some other error
                     throw err

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -1008,7 +1008,6 @@ class FormatTests(TranspileTestCase):
 
             self.assertCodeExecution(tests, js_cleaner = js_cleaner, py_cleaner = py_cleaner)
 
-        @unittest.expectedFailure
         @transforms(
             js_bool = False,
             decimal = False,


### PR DESCRIPTION
Fixes test for test_kwargs_missing_key by removing an unnecessary KeyError throw.
Removes expectedFailure decorator from this test