### PR TITLE
Update implementation of Slice

### DIFF
--- a/batavia/builtins/slice.js
+++ b/batavia/builtins/slice.js
@@ -1,17 +1,30 @@
+var exceptions = require('../core').exceptions
 var types = require('../types')
+var None = require('../core').None
 
 function slice(args, kwargs) {
+    if (!args || args.length === 0 || args.length > 3) {
+        throw new exceptions.TypeError.$pyclass('slice expected at least 1 arguments, got 0')
+    }
+
     if (args.length === 1) {
         return new types.Slice({
-            start: new types.Int(0),
+            start: None,
             stop: args[0],
-            step: new types.Int(1)
+            step: None
+
+        })
+    } else if (args.length === 2) {
+        return new types.Slice({
+            start: args[0],
+            stop: args[1],
+            step: None
         })
     } else {
         return new types.Slice({
             start: args[0],
             stop: args[1],
-            step: new types.Int(args[2] || 1)
+            step: args[2]
         })
     }
 }

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -362,27 +362,50 @@ List.prototype.__getitem__ = function(index) {
         }
     } else if (types.isinstance(index, types.Slice)) {
         var start, stop, step
-        if (index.start === null) {
+        if (index.start === None) {
             start = undefined
+        } else if (!(types.isinstance(index.start, types.Int))) {
+            if (index.start.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                start = index.start.__index__()
+            }
         } else {
-            start = index.start
+            start = index.start.int32()
         }
-        if (index.stop === null) {
-            stop = undefined
-        } else {
-            stop = index.stop
-        }
-        step = index.step
 
-        if (step === 0) {
-            throw new exceptions.ValueError.$pyclass('slice step cannot be zero')
+        if (index.stop === None) {
+            stop = undefined
+        } else if (!(types.isinstance(index.stop, types.Int))) {
+            if (index.stop.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                stop = index.stop.__index__()
+            }
+        } else {
+            stop = index.stop.int32()
+        }
+
+        if (index.step === None) {
+            step = 1
+        } else if (!(types.isinstance(index.step, types.Int))) {
+            if (index.step.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                step = index.step.__index__()
+            }
+        } else {
+            step = index.step.int32()
+            if (step === 0) {
+                throw new exceptions.ValueError.$pyclass('slice step cannot be zero')
+            }
         }
 
         // clone list
         var result = Array_.prototype.slice.call(this)
 
         // handle step
-        if (step === undefined || step === 1) {
+        if (step === 1) {
             return new List(result.slice(start, stop))
         } else if (step > 0) {
             result = result.slice(start, stop)

--- a/batavia/types/Slice.js
+++ b/batavia/types/Slice.js
@@ -10,17 +10,9 @@ function Slice(kwargs) {
     PyObject.call(this)
 
     // BUG: slices can support arbitrary-sized arguments.
-    if (kwargs.start === None) {
-        this.start = null
-    } else {
-        this.start = kwargs.start.int32()
-    }
-    if (kwargs.stop === None) {
-        this.stop = null
-    } else {
-        this.stop = kwargs.stop.int32()
-    }
-    this.step = (kwargs.step || 1) | 0
+    this.start = kwargs.start
+    this.stop = kwargs.stop
+    this.step = kwargs.step
 }
 
 Slice.prototype = Object.create(PyObject.prototype)
@@ -44,11 +36,30 @@ Slice.prototype.__repr__ = function() {
 }
 
 Slice.prototype.__str__ = function() {
-    if (this.step) {
-        return '(' + this.start + ', ' + this.stop + ', ' + this.step + ')'
+    var types = require('../types')
+    var start, stop, step
+
+    if (this.stop === None) {
+        stop = 'None'
+    } else if (types.isinstance(this.stop, types.Str)) {
+        stop = this.stop.__repr__()
     } else {
-        return '(' + this.start + ', ' + this.stop + ')'
+        stop = this.stop.__str__()
     }
+
+    if (this.start === None) {
+        start = 'None'
+    } else {
+        start = this.start
+    }
+
+    if (this.step === None) {
+        step = 'None'
+    } else {
+        step = this.step
+    }
+
+    return 'slice(' + start + ', ' + stop + ', ' + step + ')'
 }
 
 /**************************************************

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -320,20 +320,44 @@ Str.prototype.__getitem__ = function(index) {
         }
     } else if (types.isinstance(index, types.Slice)) {
         var start, stop, step
-        if (index.start === null) {
-            start = undefined
-        } else {
-            start = index.start.valueOf()
-        }
-        if (index.stop === null) {
-            stop = undefined
-        } else {
-            stop = index.stop.valueOf()
-        }
-        step = index.step.valueOf()
 
-        if (step === 0) {
-            throw new exceptions.ValueError.$pyclass('slice step cannot be zero')
+        if (index.start === None) {
+            start = undefined
+        } else if (!(types.isinstance(index.start, types.Int))) {
+            if (index.start.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                start = index.start.__index__()
+            }
+        } else {
+            start = index.start.int32()
+        }
+
+        if (index.stop === None) {
+            stop = undefined
+        } else if (!(types.isinstance(index.stop, types.Int))) {
+            if (index.stop.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                stop = index.stop.__index__()
+            }
+        } else {
+            stop = index.stop.int32()
+        }
+
+        if (index.step === None) {
+            step = 1
+        } else if (!(types.isinstance(index.step, types.Int))) {
+            if (index.step.__index__ === undefined) {
+                throw new exceptions.TypeError.$pyclass('slice indices must be integers or None or have an __index__ method')
+            } else {
+                step = index.step.__index__()
+            }
+        } else {
+            step = index.step.int32()
+            if (step === 0) {
+                throw new exceptions.ValueError.$pyclass('slice step cannot be zero')
+            }
         }
 
         // clone string

--- a/tests/builtins/test_ascii.py
+++ b/tests/builtins/test_ascii.py
@@ -18,5 +18,4 @@ class BuiltinAsciiFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_noargs',
         'test_class',
         'test_NotImplemented',
-        'test_slice',
     ]

--- a/tests/builtins/test_print.py
+++ b/tests/builtins/test_print.py
@@ -82,5 +82,4 @@ class BuiltinPrintFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_class',
         'test_NotImplemented',
-        'test_slice',
     ]

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -20,5 +20,4 @@ class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_noargs',
         'test_class',
         'test_NotImplemented',
-        'test_slice',
     ]

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -9,22 +9,6 @@ class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["slice"]
 
     not_implemented = [
-        'test_noargs',
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
         'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
         'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
     ]

--- a/tests/builtins/test_str.py
+++ b/tests/builtins/test_str.py
@@ -15,5 +15,4 @@ class BuiltinStrFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_noargs',
         'test_class',
         'test_NotImplemented',
-        'test_slice',
     ]

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -16,6 +16,21 @@ class SliceTests(TranspileTestCase):
             print("x[5::2] = ", x[5::2])
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
+
+            print("x[::-1] = ", x[::-1])
+            print("x[-5:-1:-1] = ", x[-5:-1:-1])
+            print("x[-1:0:-1] = ", x[-1:0:-1])
+            """)
+
+        # Invalid slice indices
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            print("x[2::0] = ", x[2::0])
+            print("x[::2.5] = ", x[::2.5])
+            print("x[::'a'] = ", x[::'a'])
+            print("x['a':2] = ", x['a':2])
+            print("x[1:'a':7] = ", x[1:'a':7])
+            print("x[1:None] = ", x[1:None])
             """)
 
     def test_slice_range(self):
@@ -30,6 +45,21 @@ class SliceTests(TranspileTestCase):
             print("x[5::2] = ", x[5::2])
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
+
+            print("x[::-1] = ", x[::-1])
+            print("x[-5:-1:-1] = ", x[-5:-1:-1])
+            print("x[-1:0:-1] = ", x[-1:0:-1])
+            """)
+
+        # Invalid slice indices
+        self.assertCodeExecution("""
+            x = range(0, 10)
+            print("x[2::0] = ", x[2::0])
+            print("x[::2.5] = ", x[::2.5])
+            print("x[::'a'] = ", x[::'a'])
+            print("x['a':2] = ", x['a':2])
+            print("x[1:'a':7] = ", x[1:'a':7])
+            print("x[1:None] = ", x[1:None])
             """)
 
     def test_slice_string(self):
@@ -44,6 +74,21 @@ class SliceTests(TranspileTestCase):
             print("x[5::2] = ", x[5::2])
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
+
+            print("x[::-1] = ", x[::-1])
+            print("x[-5:-1:-1] = ", x[-5:-1:-1])
+            print("x[-1:0:-1] = ", x[-1:0:-1])
+            """)
+
+        # Invalid slice indices
+        self.assertCodeExecution("""
+            x = "0123456789a"
+            print("x[2::0] = ", x[2::0])
+            print("x[::2.5] = ", x[::2.5])
+            print("x[::'a'] = ", x[::'a'])
+            print("x['a':2] = ", x['a':2])
+            print("x[1:'a':7] = ", x[1:'a':7])
+            print("x[1:None] = ", x[1:None])
             """)
 
     def test_slice_tuple(self):
@@ -58,6 +103,21 @@ class SliceTests(TranspileTestCase):
             print("x[5::2] = ", x[5::2])
             print("x[:5:2] = ", x[:5:2])
             print("x[2:8:2] = ", x[2:8:2])
+
+            print("x[::-1] = ", x[::-1])
+            print("x[-5:-1:-1] = ", x[-5:-1:-1])
+            print("x[-1:0:-1] = ", x[-1:0:-1])
+            """)
+
+        # Invalid slice indices
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            print("x[2::0] = ", x[2::0])
+            print("x[::2.5] = ", x[::2.5])
+            print("x[::'a'] = ", x[::'a'])
+            print("x['a':2] = ", x['a':2])
+            print("x[1:'a':7] = ", x[1:'a':7])
+            print("x[1:None] = ", x[1:None])
             """)
 
 

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -1036,7 +1036,6 @@ class BinaryStrOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_modulo_class',
-        'test_modulo_slice'
     ]
 
 class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
@@ -1044,5 +1043,4 @@ class InplaceStrOperationTests(InplaceOperationTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_modulo_class',
-        'test_modulo_slice'
     ]

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -94,7 +94,6 @@ class TupleTests(TranspileTestCase):
             print(e)
         """)
 
-
     def test_index(self):
         self.assertCodeExecution("""
         x = (1, 2, 2, 3)
@@ -124,6 +123,54 @@ class TupleTests(TranspileTestCase):
             print(e)
         """)
 
+    def test_slice(self):
+        # Full slice
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[:])
+            """)
+
+        # Left bound slice
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[1:])
+            """)
+
+        # Right bound slice
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[:4])
+            """)
+
+        # Slice bound in both directions
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[1:4])
+            """)
+
+        # Slice with step 0 (error)
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[::0])
+            """)
+
+        # Slice with revese step
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[::-1])
+            """)
+
+        # Slice -1 stop with reverse step
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[-5:-1:-1])
+            """)
+
+        # Slice -1 start with revese step
+        self.assertCodeExecution("""
+            x = (1, 2, 3, 4, 5)
+            print(x[-1:0:-1])
+            """)
 
 class UnaryTupleOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'tuple'


### PR DESCRIPTION
Add TypeErrors for incorrect number of parameters
Assign None instead of null if no parameter passed
Fix Slice __str__ output
Throw TypeErrors for invalid slice indicies in Str, List, Range and Tuple
Fix Tuple slice implementation to properly deal with step of 0
Add to datatype slice tests to test invalid values for step
Add to datatype slice tests to test reverse step 
Add to datatype tuple tests to test slice

Signed-off-by: Becky Smith <rebkwok@gmail.com>