### PR TITLE
Fix slice TypeError with too many args; fix Slice.__str__

### DIFF
--- a/batavia/builtins/slice.js
+++ b/batavia/builtins/slice.js
@@ -3,16 +3,13 @@ var types = require('../types')
 var None = require('../core').None
 
 function slice(args, kwargs) {
-    if (!args || args.length === 0 || args.length > 3) {
+    if (!args || args.length === 0) {
         throw new exceptions.TypeError.$pyclass('slice expected at least 1 arguments, got 0')
-    }
-
-    if (args.length === 1) {
+    } else if (args.length === 1) {
         return new types.Slice({
             start: None,
             stop: args[0],
             step: None
-
         })
     } else if (args.length === 2) {
         return new types.Slice({
@@ -20,14 +17,17 @@ function slice(args, kwargs) {
             stop: args[1],
             step: None
         })
-    } else {
+    } else if (args.length === 3) {
         return new types.Slice({
             start: args[0],
             stop: args[1],
             step: args[2]
         })
+    } else {
+        throw new exceptions.TypeError.$pyclass('slice expected at most 3 arguments, got ' + args.length)
     }
 }
+
 slice.__doc__ = 'slice(stop)\nslice(start, stop[, step])\n\nCreate a slice object.  This is used for extended slicing (e.g. a[0:10:2]).'
 
 module.exports = slice

--- a/batavia/types/Slice.js
+++ b/batavia/types/Slice.js
@@ -37,29 +37,20 @@ Slice.prototype.__repr__ = function() {
 
 Slice.prototype.__str__ = function() {
     var types = require('../types')
-    var start, stop, step
+    var output_vals = [this.start, this.stop, this.step]
+    var output_str = []
 
-    if (this.stop === None) {
-        stop = 'None'
-    } else if (types.isinstance(this.stop, types.Str)) {
-        stop = this.stop.__repr__()
-    } else {
-        stop = this.stop.__str__()
+    for (var i = 0, len = output_vals.length; i < len; i++) {
+        if (output_vals[i] === None) {
+            output_str.push('None')
+        } else if (types.isinstance(output_vals[i], types.Str)) {
+            output_str.push(output_vals[i].__repr__())
+        } else {
+            output_str.push(output_vals[i].__str__())
+        }
     }
 
-    if (this.start === None) {
-        start = 'None'
-    } else {
-        start = this.start
-    }
-
-    if (this.step === None) {
-        step = 'None'
-    } else {
-        step = this.step
-    }
-
-    return 'slice(' + start + ', ' + stop + ', ' + step + ')'
+    return 'slice(' + output_str[0] + ', ' + output_str[1] + ', ' + output_str[2] + ')'
 }
 
 /**************************************************

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -2,7 +2,31 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class SliceTests(TranspileTestCase):
-    pass
+
+    def test_slice_args(self):
+        # no args
+        self.assertCodeExecution("""
+            print("slice() = ", slice())
+        """)
+
+        # too many args
+        self.assertCodeExecution("""
+            print("slice(1, 2, 3, 4) = ", slice(1, 2, 3, 4))
+        """)
+
+        # valid number of args
+        self.assertCodeExecution("""
+            print("slice(1) = ", slice(1, 2))
+            print("slice(1, 2) = ", slice(1, 2, 3))
+            print("slice(1, 2, 3, 4) = ", slice(1, 2, 3))
+        """)
+
+    def test_slice_arg_types(self):
+        self.assertCodeExecution("""
+            print("slice('a', 'b', 'c') = ", slice('a', 'b', 'c'))
+            print("slice(None, None, None) =", slice(None, None, None))
+            print("slice(0.2, 0.0, 1.0) =", slice(0.2, 0.0, 1.0))
+        """)
 
 
 class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/datatypes/test_slice.py
+++ b/tests/datatypes/test_slice.py
@@ -23,15 +23,35 @@ class SliceTests(TranspileTestCase):
             """)
 
         # Invalid slice indices
+        # step 0
         self.assertCodeExecution("""
             x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x[2::0] = ", x[2::0])
+        """)
+        # start, stop and step must be int
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x[::2.5] = ", x[::2.5])
+        """)
+
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x[::'a'] = ", x[::'a'])
+        """)
+
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x['a':2] = ", x['a':2])
+        """)
+
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x[1:'a':7] = ", x[1:'a':7])
+        """)
+        self.assertCodeExecution("""
+            x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             print("x[1:None] = ", x[1:None])
-            """)
+        """)
 
     def test_slice_range(self):
         self.assertCodeExecution("""
@@ -52,15 +72,35 @@ class SliceTests(TranspileTestCase):
             """)
 
         # Invalid slice indices
+        # step 0
         self.assertCodeExecution("""
             x = range(0, 10)
             print("x[2::0] = ", x[2::0])
+        """)
+        # start, stop and step must be int
+        self.assertCodeExecution("""
+            x = range(0, 10)
             print("x[::2.5] = ", x[::2.5])
+        """)
+
+        self.assertCodeExecution("""
+            x = range(0, 10)
             print("x[::'a'] = ", x[::'a'])
+        """)
+
+        self.assertCodeExecution("""
+            x = range(0, 10)
             print("x['a':2] = ", x['a':2])
+        """)
+
+        self.assertCodeExecution("""
+            x = range(0, 10)
             print("x[1:'a':7] = ", x[1:'a':7])
+        """)
+        self.assertCodeExecution("""
+            x = range(0, 10)
             print("x[1:None] = ", x[1:None])
-            """)
+        """)
 
     def test_slice_string(self):
         self.assertCodeExecution("""
@@ -81,15 +121,35 @@ class SliceTests(TranspileTestCase):
             """)
 
         # Invalid slice indices
+        # step 0
         self.assertCodeExecution("""
             x = "0123456789a"
             print("x[2::0] = ", x[2::0])
+        """)
+        # start, stop and step must be int
+        self.assertCodeExecution("""
+            x = "0123456789a"
             print("x[::2.5] = ", x[::2.5])
+        """)
+
+        self.assertCodeExecution("""
+            x = "0123456789a"
             print("x[::'a'] = ", x[::'a'])
+        """)
+
+        self.assertCodeExecution("""
+            x = "0123456789a"
             print("x['a':2] = ", x['a':2])
+        """)
+
+        self.assertCodeExecution("""
+            x = "0123456789a"
             print("x[1:'a':7] = ", x[1:'a':7])
+        """)
+        self.assertCodeExecution("""
+            x = "0123456789a"
             print("x[1:None] = ", x[1:None])
-            """)
+        """)
 
     def test_slice_tuple(self):
         self.assertCodeExecution("""
@@ -109,16 +169,35 @@ class SliceTests(TranspileTestCase):
             print("x[-1:0:-1] = ", x[-1:0:-1])
             """)
 
-        # Invalid slice indices
+        # step 0
         self.assertCodeExecution("""
             x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x[2::0] = ", x[2::0])
+        """)
+        # start, stop and step must be int
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x[::2.5] = ", x[::2.5])
+        """)
+
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x[::'a'] = ", x[::'a'])
+        """)
+
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x['a':2] = ", x['a':2])
+        """)
+
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x[1:'a':7] = ", x[1:'a':7])
+        """)
+        self.assertCodeExecution("""
+            x = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             print("x[1:None] = ", x[1:None])
-            """)
+        """)
 
 
 class UnarySliceOperationTests(UnaryOperationTestCase, TranspileTestCase):


### PR DESCRIPTION
Show correct TypeError message if slice gets too many args
Fix Slice.__str__ method for start and step args that are not Int
Add tests for non-Int slice start and step args
Fix slice tests for invalid input so they all actually get tested (previously written as a block of statements which would pass if only the first one throws the expected exception)

Signed-off-by: Becky Smith <rebkwok@gmail.com>