### PR TITLE
Fix #467 - Method resolution order for object

### DIFF
--- a/batavia/core.js
+++ b/batavia/core.js
@@ -13,6 +13,7 @@ core['PYCFile'] = require('./core/types/PYCFile')
 core['Object'] = require('./core/types/Object')
 core['Type'] = require('./core/types/Type').Type
 core['type_name'] = require('./core/types/Type').type_name
+core['create_pyclass'] = require('./core/types/Type').create_pyclass
 
 core['exceptions'] = require('./core/exceptions')
 core['callables'] = require('./core/callables')

--- a/batavia/core/types/Type.js
+++ b/batavia/core/types/Type.js
@@ -160,6 +160,26 @@ PyObject.prototype.__class__ = PyObject.__class__
 PyObject.prototype.__class__.$pyclass = PyObject
 
 /*************************************************************************
+ * Method for adding types to Python class hierarchy
+ *************************************************************************/
+
+function create_pyclass(type, name, is_native) {
+    if (!is_native) {
+        extend_PyObject(type, name)
+    }
+    make_python_class(type, name)
+}
+
+function extend_PyObject(type, name) {
+    type.prototype = Object.create(PyObject.prototype)
+}
+
+function make_python_class(type, name) {
+    type.prototype.__class__ = new Type(name)
+    type.prototype.__class__.$pyclass = type
+}
+
+/*************************************************************************
  * Method for outputting the type of a variable
  *************************************************************************/
 
@@ -183,5 +203,6 @@ var type_name = function(arg) {
 
 module.exports = {
     'Type': Type,
-    'type_name': type_name
+    'type_name': type_name,
+    'create_pyclass': create_pyclass
 }

--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -1,4 +1,4 @@
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
 var utils = require('./utils')
@@ -8,8 +8,7 @@ var utils = require('./utils')
 
 var Bool = Boolean
 
-Bool.prototype.__class__ = new Type('bool')
-Bool.prototype.__class__.$pyclass = Bool
+create_pyclass(Bool, 'bool', true)
 
 /**************************************************
  * Type conversions

--- a/batavia/types/Bytearray.js
+++ b/batavia/types/Bytearray.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
 var None = require('../core').None
@@ -14,9 +14,7 @@ function Bytearray(val) {
     this.val = val
 }
 
-Bytearray.prototype = Object.create(PyObject.prototype)
-Bytearray.prototype.__class__ = new Type('bytearray')
-Bytearray.prototype.__class__.$pyclass = Bytearray
+create_pyclass(Bytearray, 'bytearray')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/BytearrayIterator.js
+++ b/batavia/types/BytearrayIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -12,9 +12,7 @@ function BytearrayIterator(data) {
     this.data = data
 };
 
-BytearrayIterator.prototype = Object.create(PyObject.prototype)
-BytearrayIterator.prototype.__class__ = new Type('bytearray_iterator')
-BytearrayIterator.prototype.__class__.$pyclass = BytearrayIterator
+create_pyclass(BytearrayIterator, 'bytearray_iterator')
 
 BytearrayIterator.prototype.__iter__ = function() {
     return this

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -1,6 +1,6 @@
 var constants = require('../core').constants
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
 var BytesIterator = require('./BytesIterator')
@@ -15,9 +15,7 @@ function Bytes(val) {
     this.val = val
 }
 
-Bytes.prototype = Object.create(PyObject.prototype)
-Bytes.prototype.__class__ = new Type('bytes')
-Bytes.prototype.__class__.$pyclass = Bytes
+create_pyclass(Bytes, 'bytes')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/BytesIterator.js
+++ b/batavia/types/BytesIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -12,9 +12,7 @@ function BytesIterator(data) {
     this.data = data
 };
 
-BytesIterator.prototype = Object.create(PyObject.prototype)
-BytesIterator.prototype.__class__ = new Type('bytes_iterator')
-BytesIterator.prototype.__class__.$pyclass = BytesIterator
+create_pyclass(BytesIterator, 'bytes_iterator')
 
 BytesIterator.prototype.__iter__ = function() {
     return this

--- a/batavia/types/Code.js
+++ b/batavia/types/Code.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python code object
@@ -28,9 +28,7 @@ function Code(kwargs) {
     // co_weakreflist
 }
 
-Code.prototype = Object.create(PyObject.prototype)
-Code.prototype.__class__ = new Type('code')
-Code.prototype.__class__.$pyclass = Code
+create_pyclass(Code, 'code')
 
 /**************************************************
  * Module exports

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -1,7 +1,7 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python complex type
@@ -84,9 +84,7 @@ function Complex(re, im) {
     }
 }
 
-Complex.prototype = Object.create(PyObject.prototype)
-Complex.prototype.__class__ = new Type('complex')
-Complex.prototype.__class__.$pyclass = Complex
+create_pyclass(Complex, 'complex')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -1,8 +1,8 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
 
 /*************************************************************************
@@ -26,9 +26,7 @@ function Dict(args, kwargs) {
     }
 }
 
-Dict.prototype = Object.create(PyObject.prototype)
-Dict.prototype.__class__ = new Type('dict')
-Dict.prototype.__class__.$pyclass = Dict
+create_pyclass(Dict, 'dict')
 
 var MAX_LOAD_FACTOR = 0.75
 var INITIAL_SIZE = 8 // after size 0

--- a/batavia/types/DictView.js
+++ b/batavia/types/DictView.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python dictview type
@@ -9,9 +9,7 @@ function DictView(args, kwargs) {
     PyObject.call(this)
 }
 
-DictView.prototype = Object.create(PyObject.prototype)
-DictView.prototype.__class__ = new Type('dictview')
-DictView.prototype.__class__.$pyclass = DictView
+create_pyclass(DictView, 'dictview')
 
 /**************************************************
  * Module exports

--- a/batavia/types/Ellipsis.js
+++ b/batavia/types/Ellipsis.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python ellipsis type
@@ -9,9 +9,7 @@ function Ellipsis(args, kwargs) {
     PyObject.call(this)
 }
 
-Ellipsis.prototype = Object.create(PyObject.prototype)
-Ellipsis.prototype.__class__ = new Type('ellipsis')
-Ellipsis.prototype.__class__.$pyclass = Ellipsis
+create_pyclass(Ellipsis, 'ellipsis')
 
 /**************************************************
  * Module exports

--- a/batavia/types/Filter.js
+++ b/batavia/types/Filter.js
@@ -1,8 +1,8 @@
 var PyObject = require('../core').Object
 var callables = require('../core').callables
 var exceptions = require('../core').exceptions
-var Type = require('../core').Type
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python filter builtin is a type
@@ -18,9 +18,7 @@ function Filter(args, kwargs) {
     this._sequence = args[1]
 }
 
-Filter.prototype = Object.create(PyObject.prototype)
-Filter.prototype.__class__ = new Type('filter')
-Filter.prototype.__class__.$pyclass = Filter
+create_pyclass(Filter, 'filter')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -1,7 +1,7 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
 
 /*************************************************************************
@@ -14,9 +14,7 @@ function Float(val) {
     this.val = val
 }
 
-Float.prototype = Object.create(PyObject.prototype)
-Float.prototype.__class__ = new Type('float')
-Float.prototype.__class__.$pyclass = Float
+create_pyclass(Float, 'float')
 
 function python_modulo(n, M) {
     return ((n % M) + M) % M

--- a/batavia/types/FrozenSet.js
+++ b/batavia/types/FrozenSet.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
@@ -20,9 +20,7 @@ function FrozenSet(args, kwargs) {
     }
 }
 
-FrozenSet.prototype = Object.create(PyObject.prototype)
-FrozenSet.prototype.__class__ = new Type('frozenset')
-FrozenSet.prototype.__class__.$pyclass = FrozenSet
+create_pyclass(FrozenSet, 'frozenset')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Function.js
+++ b/batavia/types/Function.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-extend-native */
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python function type.
@@ -73,9 +73,7 @@ function Function(name, code, globals, defaults, closure, vm) {
     this.argspec = inspect.getfullargspec(this)
 }
 
-Function.prototype = Object.create(PyObject.prototype)
-Function.prototype.__class__ = new Type('function')
-Function.prototype.__class__.$pyclass = Function
+create_pyclass(Function, 'function')
 
 Function.prototype.__get__ = function(instance, klass) {
     var types = require('../types')

--- a/batavia/types/Generator.js
+++ b/batavia/types/Generator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /*************************************************************************
@@ -15,9 +15,7 @@ function Generator(frame, vm) {
     this.finished = false
 };
 
-Generator.prototype = Object.create(PyObject.prototype)
-Generator.prototype.__class__ = new Type('generator')
-Generator.prototype.__class__.$pyclass = Generator
+create_pyclass(Generator, 'generator')
 
 Generator.prototype.__iter__ = function() {
     return this

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -1,9 +1,9 @@
 var BigNumber = require('bignumber.js')
 
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
 var utils = require('./utils')
 
@@ -16,9 +16,7 @@ function Int(val) {
     this.val = new BigNumber(val)
 }
 
-Int.prototype = Object.create(PyObject.prototype)
-Int.prototype.__class__ = new Type('int')
-Int.prototype.__class__.$pyclass = Int
+create_pyclass(Int, 'int')
 
 var REASONABLE_SHIFT = new Int('8192')
 var MAX_SHIFT = new Int('9223372036854775807')

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -1,8 +1,8 @@
 var constants = require('../core').constants
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
 var ListIterator = require('./ListIterator')
 
@@ -37,8 +37,7 @@ Array_.prototype = []
 
 List.prototype = Object.create(Array_.prototype)
 List.prototype.length = 0
-List.prototype.__class__ = new Type('list')
-List.prototype.__class__.$pyclass = List
+create_pyclass(List, 'list', true)
 List.prototype.constructor = List
 
 /**************************************************

--- a/batavia/types/ListIterator.js
+++ b/batavia/types/ListIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -12,9 +12,7 @@ function ListIterator(data) {
     this.data = data
 };
 
-ListIterator.prototype = Object.create(PyObject.prototype)
-ListIterator.prototype.__class__ = new Type('list_iterator')
-ListIterator.prototype.__class__.$pyclass = ListIterator
+create_pyclass(ListIterator, 'list_iterator')
 
 ListIterator.prototype.__iter__ = function() {
     return this

--- a/batavia/types/Map.js
+++ b/batavia/types/Map.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-extend-native */
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python map builtin is a type
@@ -19,9 +19,7 @@ function Map(args, kwargs) {
     this._sequence = args[1]
 }
 
-Map.prototype = Object.create(PyObject.prototype)
-Map.prototype.__class__ = new Type('map')
-Map.prototype.__class__.$pyclass = Map
+create_pyclass(Map, 'map')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Method.js
+++ b/batavia/types/Method.js
@@ -1,4 +1,4 @@
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var Function = require('./Function')
 
 /*************************************************************************
@@ -21,8 +21,7 @@ function Method(instance, func) {
 }
 
 Method.prototype = Object.create(Function.prototype)
-Method.prototype.__class__ = new Type('method')
-Method.prototype.__class__.$pyclass = Method
+create_pyclass(Method, 'method', true)
 
 /**************************************************
  * Module exports

--- a/batavia/types/Module.js
+++ b/batavia/types/Module.js
@@ -1,4 +1,4 @@
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var JSDict = require('./JSDict')
 
 /*************************************************************************
@@ -14,8 +14,7 @@ function Module(name, filename, pkg) {
 }
 
 Module.prototype = Object.create(JSDict.prototype)
-Module.prototype.__class__ = new Type('module')
-Module.prototype.__class__.$pyclass = Module
+create_pyclass(Module, 'module', true)
 
 /**************************************************
  * Module exports

--- a/batavia/types/Property.js
+++ b/batavia/types/Property.js
@@ -1,9 +1,9 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var None = require('../core').None
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 // var None = require('../core').None;
 
 /*************************************************************************
@@ -19,9 +19,7 @@ function Property(fget, fset, fdel, doc) {
     this.doc = doc
 }
 
-Property.prototype = Object.create(PyObject.prototype)
-Property.prototype.__class__ = new Type('property')
-Property.prototype.__class__.$pyclass = Property
+create_pyclass(Property, 'property')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Range.js
+++ b/batavia/types/Range.js
@@ -1,9 +1,9 @@
 var BigNumber = require('bignumber.js')
 
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var RangeIterator = require('./RangeIterator')
 var None = require('../core').None
 
@@ -36,9 +36,7 @@ function Range(start, stop, step) {
     }
 }
 
-Range.prototype = Object.create(PyObject.prototype)
-Range.prototype.__class__ = new Type('range')
-Range.prototype.__class__.$pyclass = Range
+create_pyclass(Range, 'range')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/RangeIterator.js
+++ b/batavia/types/RangeIterator.js
@@ -1,8 +1,8 @@
 var BigNumber = require('bignumber.js')
 
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
+var create_pyclass = require('../core').create_pyclass
 
 /**************************************************
  * Range Iterator
@@ -15,9 +15,7 @@ function RangeIterator(data) {
     this.stop = data.stop
 }
 
-RangeIterator.prototype = Object.create(PyObject.prototype)
-RangeIterator.prototype.__class__ = new Type('range_iterator')
-RangeIterator.prototype.__class__.$pyclass = RangeIterator
+create_pyclass(RangeIterator, 'range_iterator')
 
 RangeIterator.prototype.__next__ = function() {
     var types = require('../types')

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-extend-native */
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * A Python Set type, with an underlying Dict.
@@ -20,9 +20,7 @@ function Set(args, kwargs) {
     }
 }
 
-Set.prototype = Object.create(PyObject.prototype)
-Set.prototype.__class__ = new Type('set')
-Set.prototype.__class__.$pyclass = Set
+create_pyclass(Set, 'set')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/SetIterator.js
+++ b/batavia/types/SetIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -13,9 +13,7 @@ function SetIterator(data) {
     this.keys = data.data.keys()
 }
 
-SetIterator.prototype = Object.create(PyObject.prototype)
-SetIterator.prototype.__class__ = new Type('set_iterator')
-SetIterator.prototype.__class__.$pyclass = SetIterator
+create_pyclass(SetIterator, 'set_iterator')
 
 SetIterator.prototype.__next__ = function() {
     var key = this.keys[this.index]

--- a/batavia/types/Slice.js
+++ b/batavia/types/Slice.js
@@ -1,6 +1,6 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var None = require('../core').None
+var create_pyclass = require('../core').create_pyclass
 
 /*************************************************************************
  * An implementation of slice
@@ -15,9 +15,7 @@ function Slice(kwargs) {
     this.step = kwargs.step
 }
 
-Slice.prototype = Object.create(PyObject.prototype)
-Slice.prototype.__class__ = new Type('slice')
-Slice.prototype.__class__.$pyclass = Slice
+create_pyclass(Slice, 'slice')
 
 /**************************************************
  * Javascript compatibility methods

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -2,9 +2,9 @@ var Buffer = require('buffer').Buffer
 
 var PyObject = require('../core').Object
 var constants = require('../core').constants
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
 var StrIterator = require('./StrIterator')
 var StrUtils = require('./StrUtils')
@@ -15,8 +15,7 @@ var StrUtils = require('./StrUtils')
 
 var Str = String
 
-Str.prototype.__class__ = new Type('str')
-Str.prototype.__class__.$pyclass = Str
+create_pyclass(Str, 'str', true)
 
 /**************************************************
  * Type conversions

--- a/batavia/types/StrIterator.js
+++ b/batavia/types/StrIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -12,9 +12,7 @@ function StrIterator(data) {
     this.data = data
 }
 
-StrIterator.prototype = Object.create(PyObject.prototype)
-StrIterator.prototype.__class__ = new Type('str_iterator')
-StrIterator.prototype.__class__.$pyclass = StrIterator
+create_pyclass(StrIterator, 'str_iterator')
 
 StrIterator.prototype.__next__ = function() {
     var retval = this.data[this.index]

--- a/batavia/types/StrIterator.js
+++ b/batavia/types/StrIterator.js
@@ -13,7 +13,7 @@ function StrIterator(data) {
 }
 
 StrIterator.prototype = Object.create(PyObject.prototype)
-StrIterator.__class__ = new Type('str_iterator')
+StrIterator.prototype.__class__ = new Type('str_iterator')
 StrIterator.prototype.__class__.$pyclass = StrIterator
 
 StrIterator.prototype.__next__ = function() {

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -1,9 +1,9 @@
 var constants = require('../core').constants
 var PyObject = require('../core').Object
-var Type = require('../core').Type
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
 var TupleIterator = require('./TupleIterator')
 var None = require('../core').None
 
@@ -39,8 +39,7 @@ Array_.prototype = []
 
 Tuple.prototype = Object.create(Array_.prototype)
 Tuple.prototype.length = 0
-Tuple.prototype.__class__ = new Type('tuple')
-Tuple.prototype.__class__.$pyclass = Tuple
+create_pyclass(Tuple, 'tuple', true)
 Tuple.prototype.constructor = Tuple
 
 /**************************************************

--- a/batavia/types/TupleIterator.js
+++ b/batavia/types/TupleIterator.js
@@ -1,5 +1,5 @@
 var PyObject = require('../core').Object
-var Type = require('../core').Type
+var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
 
 /**************************************************
@@ -12,9 +12,7 @@ function TupleIterator(data) {
     this.data = data
 }
 
-TupleIterator.prototype = Object.create(PyObject.prototype)
-TupleIterator.prototype.__class__ = new Type('tuple_iterator')
-TupleIterator.prototype.__class__.$pyclass = TupleIterator
+create_pyclass(TupleIterator, 'tuple_iterator')
 
 TupleIterator.prototype.__next__ = function() {
     var retval = this.data[this.index]

--- a/tests/builtins/test_next.py
+++ b/tests/builtins/test_next.py
@@ -33,8 +33,3 @@ class NextTests(TranspileTestCase):
 
 class BuiltinNextFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["next"]
-
-    not_implemented = [
-        'test_frozenset',
-        'test_set',
-    ]


### PR DESCRIPTION
The bug (https://github.com/pybee/batavia/issues/467) caused PyObject's `__class__.$pyclass` to be changed from
PyObject to `str_iterator` in StrIterator.js, which for example, messed
with chain of inheritance multiple classes.