### PR TITLE
Allow indexing tuples with Booleans.

### DIFF
--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -325,7 +325,11 @@ Tuple.prototype.__getitem__ = function(index) {
             }
         }
     } else if (types.isinstance(index, types.Bool)) {
-        return this[index ? 1 : 0];
+        if (index) {
+            return this[1]
+        } else {
+            return this[0]
+        }
     } else if (types.isinstance(index, types.Slice)) {
         var start, stop, step
         if (index.start === None) {

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -324,6 +324,8 @@ Tuple.prototype.__getitem__ = function(index) {
                 return this[idx]
             }
         }
+    } else if (types.isinstance(index, types.Bool)) {
+        return this[index ? 1 : 0];
     } else if (types.isinstance(index, types.Slice)) {
         var start, stop, step
         if (index.start === None) {

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -325,10 +325,14 @@ Tuple.prototype.__getitem__ = function(index) {
             }
         }
     } else if (types.isinstance(index, types.Bool)) {
-        if (index) {
-            return this[1]
+        if (index >= this.length) {
+            throw new exceptions.IndexError.$pyclass('tuple index out of range')
         } else {
-            return this[0]
+            if (index) {
+                return this[1]
+            } else {
+                return this[0]
+            }
         }
     } else if (types.isinstance(index, types.Slice)) {
         var start, stop, step

--- a/tests/datatypes/test_tuple.py
+++ b/tests/datatypes/test_tuple.py
@@ -179,10 +179,6 @@ class UnaryTupleOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinaryTupleOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'tuple'
 
-    not_implemented = [
-        'test_subscr_bool',
-    ]
-
 
 class InplaceTupleOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'tuple'


### PR DESCRIPTION
Fixes a problem where using a boolean as a tuple index in python code would throw an exception.