### PR TITLE
Fixed Bool so that calls to `setattr` now fail correctly.

### DIFF
--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -500,6 +500,10 @@ Bool.prototype.__getitem__ = function(other) {
     throw new exceptions.TypeError.$pyclass("'bool' object is not subscriptable")
 }
 
+Bool.prototype.__setattr__ = function(other) {
+    throw new exceptions.AttributeError.$pyclass("'bool' object has no attribute '" + other + "'")
+}
+
 Bool.prototype.__lshift__ = function(other) {
     var types = require('../types')
     var this_bool

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -4,7 +4,6 @@ import unittest
 
 
 class BoolTests(TranspileTestCase):
-    @unittest.expectedFailure
     def test_setattr(self):
         self.assertCodeExecution("""
             x = True


### PR DESCRIPTION
This removes an expected failure & makes the error exactly match the Python 3 variant.