### PR TITLE
Add workaround for Safari 9 Support

### DIFF
--- a/batavia/core/types/PYCFile.js
+++ b/batavia/core/types/PYCFile.js
@@ -5,6 +5,12 @@ var constants = require('../constants')
  *************************************************************************/
 
 var PYCFile = function(data) {
+
+    if (!Uint8Array.prototype.slice) {
+        Object.defineProperty(Uint8Array.prototype, 'slice', {
+            value: Array.prototype.slice
+        });
+    }
     Object.call(this)
     this.magic = data.slice(0, 4)
     this.modtime = data.slice(4, 8)

--- a/batavia/core/types/PYCFile.js
+++ b/batavia/core/types/PYCFile.js
@@ -5,11 +5,10 @@ var constants = require('../constants')
  *************************************************************************/
 
 var PYCFile = function(data) {
-
     if (!Uint8Array.prototype.slice) {
-        Object.defineProperty(Uint8Array.prototype, 'slice', {
+        Object.defineProperty(Uint8Array.prototype, 'slice', { // eslint-disable-line no-extend-native
             value: Array.prototype.slice
-        });
+        })
     }
     Object.call(this)
     this.magic = data.slice(0, 4)


### PR DESCRIPTION
This pull request is intended to resolve issue #520 by adding a workaround for Safari 9's lack of implementation for TypedArray.prototype.slice(), per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice