### PR TITLE
Fixed Int so that calls to `setattr` now fail correctly.

### DIFF
--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -489,6 +489,10 @@ Int.prototype.__getitem__ = function(index) {
     throw new exceptions.TypeError.$pyclass("'int' object is not subscriptable")
 }
 
+Int.prototype.__setattr__ = function(other) {
+    throw new exceptions.AttributeError.$pyclass("'int' object has no attribute '" + other + "'")
+}
+
 /**************************************************
  * Bitshift and logical ops
  **************************************************/

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -4,7 +4,6 @@ import unittest
 
 
 class IntTests(TranspileTestCase):
-    @unittest.expectedFailure
     def test_setattr(self):
         self.assertCodeExecution("""
             x = 37


### PR DESCRIPTION
This removes an expected failure & makes the error exactly match the Python 3 variant.