### PR TITLE
Lots of word-wrapping, and a more accurate sandbox tutorial

### DIFF
--- a/docs/community/community.rst
+++ b/docs/community/community.rst
@@ -5,9 +5,17 @@ Batavia is part of the `BeeWare suite`_. You can talk to the community through:
 
 * `@pybeeware on Twitter`_
 
-* The `BeeWare Users Mailing list`_, for questions about how to use the BeeWare suite.
+* See the `Getting Help`_ page for information on where to ask
+  questions regarding the use of the BeeWare suite, as well as links
+  to discussions the development of new features in the BeeWare suite,
+  and ideas for new tools for the suite.
 
-* The `BeeWare Developers Mailing list`_, for discussing the development of new features in the BeeWare suite, and ideas for new tools for the suite.
+* The original `BeeWare Users`_ and `BeeWare Developers`_ mailing
+  lists, have been shut down, in favor of the `getting help`_ page
+  mentioned above. However, the earlier messages and topics posted
+  prior to its shutdown remain. See the `announcement`_ for more
+  details on the shutdown.
+
 
 Code of Conduct
 ---------------
@@ -24,8 +32,10 @@ want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
-.. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
-.. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers
+.. _Getting Help: https://pybee.org/community/getting-help/
+.. _announcement: https://groups.google.com/forum/#!topic/beeware-users/iUm-EDgypTg
+.. _BeeWare Users: https://groups.google.com/forum/#!forum/beeware-users
+.. _BeeWare Developers: https://groups.google.com/forum/#!forum/beeware-developers
 .. _log them on Github: https://github.com/pybee/batavia/issues
 .. _fork the code: https://github.com/pybee/batavia
 .. _submit a pull request: https://github.com/pybee/batavia/pulls

--- a/docs/intro/tutorial-1.rst
+++ b/docs/intro/tutorial-1.rst
@@ -38,19 +38,25 @@ Starting the test server
 4. Now open your browser and go to `http://localhost:8000 <http://localhost:8000>`_
 
 
-You should now see a page titled "Batavia testbed" with some buttons on the left and a text box on the right.
+You should now see a page titled "Batavia testbed" divided into three sections:
+
+- a top section with text box for entering your Python code and a
+  "Run your code!" button
+- a middle section with buttons for running sample Python scripts
+- a *Console output* section at the bottom of the page that displays
+  the results from running either your own code or any of the samples.
 
 It's alive!
 -----------
 
-On the right hand side of the screen is a text box. This is where you can enter your
+At the top of the page is a text box. This is where you can enter your
 Python code. Type the following into this text box:
 
 .. code-block:: python
 
     print("Hello World!")
 
-Then click on the "Run code" button. The page will reload, and below the area
+Then click on the "Run your code!" button. The page will reload, and below the area
 on the page named "Console output", you'll see the output you'd
 expect from this Python program::
 
@@ -65,7 +71,7 @@ your existing code in the text box with the following:
     for i in range(0, 10):
         print("Hello World %d!" % i)
 
-Click "Run code" again, and you should see the following on the screen in the
+Click "Run your code!" again, and you should see the following on the screen in the
 console output section::
 
     Hello World 0!
@@ -83,9 +89,9 @@ console output section::
 What just happened?
 -------------------
 
-What happened when you pressed the "Run code" button?
+What happened when you pressed the "Run your code!" button?
 
-When you clicked "Run code", your browser submitted the content of the text
+When you clicked "Run your code!", your browser submitted the content of the text
 box as a HTTP ``POST`` request to the test server. The test server took that
 content, and compiled it as if it were Python code. It didn't *run* the code --
 it just compiled it to bytecode. It created the ``.pyc`` file that
@@ -114,8 +120,9 @@ interprets Python bytecode as a running program.
 Push the button...
 ------------------
 
-You may also have noticed a set of buttons on the left hand side of the
-screen. These are some pre-canned example code, ready for testing. Try
+You may also have noticed a set of buttons between the text box at the top
+of the page and the Console output section.
+These are some pre-canned example code, ready for testing. Try
 clicking the "Run sample.py" button. Your browser should pop
 up a new window and load the `BeeWare website`_. If you close that window and
 go back to the Batavia testbed, you should see a lot of output in the console
@@ -124,7 +131,7 @@ section of the screen.
 .. _BeeWare website: http://pybee.org
 
 Inside the button
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 If you want to, you can `inspect the source code`_. One part of
 ``sample.py`` that is of particular interest is the part that opens the new
@@ -153,7 +160,7 @@ page title, and add some text to the end of an element. The entire browser DOM
 is exposed in this way, so anything you can do in Javascript, you can do in
 Batavia.
 
-You can even use this code in the sample code window: copy and paste this code into the "run code" text box, click "Run code", and you get a popup window.
+You can even use this code in the sample code window: copy and paste this code into the "run code" text box, click "Run your code!", and you get a popup window.
 
 .. _inspect the source code: https://github.com/pybee/batavia/blob/master/testserver/sample.py
 


### PR DESCRIPTION
I believe markdown and reStructuredText are both designed to be readable in a 80-character width console window. So, I wrapped wherever I could.

Also, the tutorial for the sandbox described a different screen layout than what I was seeing. So, I changed the text to agree with the location of the sections as they currently appear on the screen.

The community "getting help" needed updating as well.