### PR TITLE
Issue #181: python36 bytecode compatibility (for dicts and others)

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -289,6 +289,18 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                             this.push(items[0] | items[1])
                         }
                     }
+                case 'MATRIX_MULTIPLY':
+                    return function() {
+                        var items = this.popn(2)
+                        if (items[0] === null) {
+                            this.push(types.NoneType.__matmul__(items[1]))
+                        } else if (items[0].__matmul__) {
+                            this.push(items[0].__matmul__(items[1]))
+                        } else {
+                            // TODO: This default action might be misleading.
+                            this.push(items[0] * items[1])
+                        }
+                    }
                 default:
                     throw new builtins.BataviaError.$pyclass('Unknown binary operator ' + operator_name)
             }
@@ -495,6 +507,24 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                             }
                         } else {
                             items[0] |= items[1]
+                            result = items[0]
+                        }
+                        this.push(result)
+                    }
+                case 'MATRIX_MULTIPLY':
+                    return function() {
+                        var items = this.popn(2)
+                        var result
+                        if (items[0] === null) {
+                            result = types.NoneType.__imul__(items[1])
+                        } else if (items[0].__imul__) {
+                            result = items[0].__imul__(items[1])
+                            if (result === null) {
+                                result = items[0]
+                            }
+                        } else {
+                            // TODO: fallback multiply might be misleading
+                            items[0] *= items[1]
                             result = items[0]
                         }
                         this.push(result)

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1832,7 +1832,7 @@ VirtualMachine.prototype.byte_CALL_FUNCTION_KW = function(arg) {
     return this.call_function(arg, null, kwargs)
 }
 
-VirtualMachine.prototype.byte_CALL_FUNCTION_VAR_KW = function(arg) {
+VirtualMachine.prototype.byte_CALL_FUNCTION_EX = function(arg) {
     var items = this.popn(2)
     return this.call_function(arg, items[0], items[1])
 }

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -2098,8 +2098,17 @@ VirtualMachine.prototype.byte_FORMAT_VALUE = function() {
     // See Python/ceval.c around line 3429
 }
 
-VirtualMachine.prototype.byte_BUILD_CONST_KEY_MAP = function() {
+VirtualMachine.prototype.byte_BUILD_CONST_KEY_MAP = function(size) {
     // See Python/ceval.c around line 2688
+    var keys = this.pop()
+    var values = this.popn(size)
+    var dict = new types.Dict()
+
+    for (var i = 0; i < values.length; i += 1) {
+        dict.__setitem__(keys[i], values[i])
+    }
+    this.push(dict)
+    return
 }
 
 VirtualMachine.prototype.byte_BUILD_STRING = function() {

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -2031,7 +2031,7 @@ VirtualMachine.prototype.byte_SET_LINENO = function(lineno) {
 VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {
 }
 
-// Additions for Python 3.6 opcodes added here
+// Additions for Python 3.6+ opcodes added here
 
 VirtualMachine.prototype.byte_GET_AITER = function() {
     // See Python/ceval.c around line 1929
@@ -2043,6 +2043,14 @@ VirtualMachine.prototype.byte_GET_ANEXT = function() {
 
 VirtualMachine.prototype.byte_BEFORE_ASYNC_WITH = function() {
     // See Python/ceval.c around line 3006
+}
+
+VirtualMachine.prototype.byte_SETUP_ANNOTATIONS = function() {
+    // See Python/ceval.c around line 2596
+}
+
+VirtualMachine.prototype.byte_STORE_ANNOTATION = function() {
+    // See Python/ceval.c around line 1698
 }
 
 VirtualMachine.prototype.byte_GET_YIELD_FROM_ITER = function() {
@@ -2083,6 +2091,22 @@ VirtualMachine.prototype.byte_BUILD_TUPLE_UNPACK = function() {
 
 VirtualMachine.prototype.byte_BUILD_SET_UNPACK = function() {
     // See Python/ceval.c around line 2544
+}
+
+VirtualMachine.prototype.byte_FORMAT_VALUE = function() {
+    // See Python/ceval.c around line 3429
+}
+
+VirtualMachine.prototype.byte_BUILD_CONST_KEY_MAP = function() {
+    // See Python/ceval.c around line 2688
+}
+
+VirtualMachine.prototype.byte_BUILD_STRING = function() {
+    // See Python/ceval.c around line 2478
+}
+
+VirtualMachine.prototype.byte_BUILD_TUPLE_UNPACK_WITH_CALL = function() {
+    // See Python/ceval.c around line 2520
 }
 
 module.exports = VirtualMachine

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -2031,4 +2031,58 @@ VirtualMachine.prototype.byte_SET_LINENO = function(lineno) {
 VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {
 }
 
+// Additions for Python 3.6 opcodes added here
+
+VirtualMachine.prototype.byte_GET_AITER = function() {
+    // See Python/ceval.c around line 1929
+}
+
+VirtualMachine.prototype.byte_GET_ANEXT = function() {
+    // See Python/ceval.c around line 1976
+}
+
+VirtualMachine.prototype.byte_BEFORE_ASYNC_WITH = function() {
+    // See Python/ceval.c around line 3006
+}
+
+VirtualMachine.prototype.byte_GET_YIELD_FROM_ITER = function() {
+    // See Python/ceval.c around line 2926
+}
+
+VirtualMachine.prototype.byte_GET_AWAITABLE = function() {
+    // See Python/ceval.c around line 2018
+}
+
+VirtualMachine.prototype.byte_WITH_CLEANUP_START = function() {
+    // See Python/ceval.c around line 3065
+}
+
+VirtualMachine.prototype.byte_WITH_CLEANUP_FINISH = function() {
+    // See Python/ceval.c around line 3150
+}
+
+VirtualMachine.prototype.byte_SETUP_ASYNC_WITH = function() {
+    // See Python/ceval.c around line 3029
+}
+
+VirtualMachine.prototype.byte_BUILD_LIST_UNPACK = function() {
+    // See Python/ceval.c around line 2489
+}
+
+VirtualMachine.prototype.byte_BUILD_MAP_UNPACK = function() {
+    // See Python/ceval.c around line 2588
+}
+
+VirtualMachine.prototype.byte_BUILD_MAP_UNPACK_WITH_CALL = function() {
+    // See Python/ceval.c around line 2587
+}
+
+VirtualMachine.prototype.byte_BUILD_TUPLE_UNPACK = function() {
+    // See Python/ceval.c around line 2488
+}
+
+VirtualMachine.prototype.byte_BUILD_SET_UNPACK = function() {
+    // See Python/ceval.c around line 2544
+}
+
 module.exports = VirtualMachine

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -516,9 +516,9 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         var items = this.popn(2)
                         var result
                         if (items[0] === null) {
-                            result = types.NoneType.__imul__(items[1])
-                        } else if (items[0].__imul__) {
-                            result = items[0].__imul__(items[1])
+                            result = types.NoneType.__imatmul__(items[1])
+                        } else if (items[0].__imatmul__) {
+                            result = items[0].__imatmul__(items[1])
                             if (result === null) {
                                 result = items[0]
                             }

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -782,10 +782,10 @@ VirtualMachine.prototype.unpack_code = function(code) {
     var lo
     var hi
 
-    while (pos < code.co_code.val.length) {
+    // while (pos < code.co_code.val.length) {
+    for (pos = 0; pos < code.co_code.val.length; pos += 2) {
         var opcode_start_pos = pos
-
-        var opcode = code.co_code.val[pos++]
+        var opcode = code.co_code.val[pos]
 
         // next opcode has 4-byte argument effectively.
         if (opcode === dis.EXTENDED_ARG) {
@@ -827,9 +827,10 @@ VirtualMachine.prototype.unpack_code = function(code) {
         if (opcode < dis.HAVE_ARGUMENT) {
             args = []
         } else {
-            lo = code.co_code.val[pos++]
-            hi = code.co_code.val[pos++]
-            var intArg = lo | (hi << 8) | extra
+            // lo = code.co_code.val[pos++]
+            // hi = code.co_code.val[pos++]
+            // var intArg = lo | (hi << 8) | extra
+            var intArg = code.co_code.val[pos + 1]
             extra = 0 // use extended arg if present
 
             if (opcode in dis.hasconst) {
@@ -859,7 +860,7 @@ VirtualMachine.prototype.unpack_code = function(code) {
             'opcode': opcode,
             'op_method': this.dispatch_table[opcode],
             'args': args,
-            'next_pos': pos
+            'next_pos': pos + 2
         }
     }
 

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1725,7 +1725,7 @@ VirtualMachine.prototype.byte_POP_EXCEPT = function() {
 //             this.push_block('finally', dest)
 //         this.push(ctxmgr_obj)
 // }
-// VirtualMachine.prototype.byte_WITH_CLEANUP = function {
+// VirtualMachine.prototype.byte_WITH_CLEANUP_START = function {
 //         // The code here does some weird stack manipulation: the exit function
 //         // is buried in the stack, and where depends on what's on top of it.
 //         // Pull out the exit function, and leave the rest in place.
@@ -1754,7 +1754,7 @@ VirtualMachine.prototype.byte_POP_EXCEPT = function() {
 //                 block = this.pop_block()
 //                 this.push_block(block.type, block.handler, block.level-1)
 //         else:       // pragma: no cover
-//             throw "Confused WITH_CLEANUP")
+//             throw "Confused WITH_CLEANUP_START")
 //         exit_ret = exit_func(u, v, w)
 //         err = (u is not null) and bool(exit_ret)
 //         if err:

--- a/batavia/core/constants.js
+++ b/batavia/core/constants.js
@@ -13,7 +13,8 @@ var constants = {
     'BATAVIA_MAGIC_34': String.fromCharCode(238, 12, 13, 10),
     'BATAVIA_MAGIC_35a0': String.fromCharCode(248, 12, 13, 10),
     'BATAVIA_MAGIC_35': String.fromCharCode(22, 13, 13, 10),
-    'BATAVIA_MAGIC_353': String.fromCharCode(23, 13, 13, 10)
+    'BATAVIA_MAGIC_353': String.fromCharCode(23, 13, 13, 10),
+    'BATAVIA_MAGIC_361': String.fromCharCode(51, 13, 13, 10)
 }
 
 module.exports = constants

--- a/batavia/modules/dis.js
+++ b/batavia/modules/dis.js
@@ -206,7 +206,7 @@ def_op('CALL_FUNCTION_VAR', 140)     // #args + (#kwargs << 8);
 dis.hasnargs[140] = 140
 def_op('CALL_FUNCTION_KW', 141)      // #args + (#kwargs << 8);
 dis.hasnargs[141] = 141
-def_op('CALL_FUNCTION_VAR_KW', 142)  // #args + (#kwargs << 8);
+def_op('CALL_FUNCTION_EX', 142)  // #args + (#kwargs << 8);
 dis.hasnargs[142] = 142
 
 jrel_op('SETUP_WITH', 143)

--- a/batavia/modules/dis.js
+++ b/batavia/modules/dis.js
@@ -84,6 +84,9 @@ def_unary_op('UNARY_NOT', 12)
 
 def_unary_op('UNARY_INVERT', 15)
 
+def_binary_op('BINARY_MATRIX_MULTIPLY', 16)
+def_inplace_op('INPLACE_MATRIX_MULTIPLY', 17)
+
 def_binary_op('BINARY_POWER', 19)
 def_binary_op('BINARY_MULTIPLY', 20)
 
@@ -95,6 +98,10 @@ def_binary_op('BINARY_FLOOR_DIVIDE', 26)
 def_binary_op('BINARY_TRUE_DIVIDE', 27)
 def_inplace_op('INPLACE_FLOOR_DIVIDE', 28)
 def_inplace_op('INPLACE_TRUE_DIVIDE', 29)
+
+def_op('GET_AITER', 50)
+def_op('GET_ANEXT', 51)
+def_op('BEFORE_ASYNC_WITH', 52)
 
 def_op('STORE_MAP', 54)
 def_inplace_op('INPLACE_ADD', 55)
@@ -111,10 +118,12 @@ def_binary_op('BINARY_XOR', 65)
 def_binary_op('BINARY_OR', 66)
 def_inplace_op('INPLACE_POWER', 67)
 def_op('GET_ITER', 68)
+def_op('GET_YIELD_FROM_ITER', 69)
 
 def_op('PRINT_EXPR', 70)
 def_op('LOAD_BUILD_CLASS', 71)
 def_op('YIELD_FROM', 72)
+def_op('GET_AWAITABLE', 73)
 
 def_inplace_op('INPLACE_LSHIFT', 75)
 def_inplace_op('INPLACE_RSHIFT', 76)
@@ -122,7 +131,8 @@ def_inplace_op('INPLACE_AND', 77)
 def_inplace_op('INPLACE_XOR', 78)
 def_inplace_op('INPLACE_OR', 79)
 def_op('BREAK_LOOP', 80)
-def_op('WITH_CLEANUP', 81)
+def_op('WITH_CLEANUP_START', 81)
+def_op('WITH_CLEANUP_FINISH', 82)
 
 def_op('RETURN_VALUE', 83)
 def_op('IMPORT_STAR', 84)
@@ -208,7 +218,15 @@ def_op('MAP_ADD', 147)
 def_op('LOAD_CLASSDEREF', 148)
 dis.hasfree[148] = 148
 
+jrel_op('SETUP_ASYNC_WITH', 154)  // Appears out of order in Lib/opcode.py
+
 def_op('EXTENDED_ARG', 144)
 dis.EXTENDED_ARG = 144
+
+def_op('BUILD_LIST_UNPACK', 149)
+def_op('BUILD_MAP_UNPACK', 150)
+def_op('BUILD_MAP_UNPACK_WITH_CALL', 151)
+def_op('BUILD_TUPLE_UNPACK', 152)
+def_op('BUILD_SET_UNPACK', 153)
 
 module.exports = dis

--- a/batavia/modules/dis.js
+++ b/batavia/modules/dis.js
@@ -136,7 +136,7 @@ def_op('WITH_CLEANUP_FINISH', 82)
 
 def_op('RETURN_VALUE', 83)
 def_op('IMPORT_STAR', 84)
-
+def_op('SETUP_ANNOTATIONS', 85)
 def_op('YIELD_VALUE', 86)
 def_op('POP_BLOCK', 87)
 def_op('END_FINALLY', 88)
@@ -186,6 +186,7 @@ def_op('STORE_FAST', 125)       // Local variable number
 dis.haslocal[125] = 125
 def_op('DELETE_FAST', 126)      // Local variable number
 dis.haslocal[126] = 126
+name_op('STORE_ANNOTATION', 127) // Index in name list
 
 def_op('RAISE_VARARGS', 130)    // Number of raise arguments (1, 2, or 3);
 def_op('CALL_FUNCTION', 131)    // #args + (#kwargs << 8);
@@ -218,8 +219,6 @@ def_op('MAP_ADD', 147)
 def_op('LOAD_CLASSDEREF', 148)
 dis.hasfree[148] = 148
 
-jrel_op('SETUP_ASYNC_WITH', 154)  // Appears out of order in Lib/opcode.py
-
 def_op('EXTENDED_ARG', 144)
 dis.EXTENDED_ARG = 144
 
@@ -228,5 +227,12 @@ def_op('BUILD_MAP_UNPACK', 150)
 def_op('BUILD_MAP_UNPACK_WITH_CALL', 151)
 def_op('BUILD_TUPLE_UNPACK', 152)
 def_op('BUILD_SET_UNPACK', 153)
+
+jrel_op('SETUP_ASYNC_WITH', 154)
+
+def_op('FORMAT_VALUE', 155)
+def_op('BUILD_CONST_KEY_MAP', 156)
+def_op('BUILD_STRING', 157)
+def_op('BUILD_TUPLE_UNPACK_WITH_CALL', 158)
 
 module.exports = dis

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.4.4
+    version: 3.6.1
   node:
     version: 6.9.1
   timezone:


### PR DESCRIPTION
This PR is still a WIP for discussion, since several details still need to be addressed:

- CPython 3.6 bytecodes are now 2 bytes instead of 1 byte (Issue #71)
- The implementations of the new opcodes are all still empty
- I have not yet looked at the specific issue in #181 (about dicts specifically)
- I have not added any test code yet. 

Note that this PR also includes implementations for the `__matmul__` and `__imatmul__` methods for the `BINARY_MATRIX_MULTIPLY` and `INPLACE_MATRIX_MULTIPLY` special methods. These changes are not required for 3.6 compat but they were easy to add.  They can be moved into a separate PR if desired.

Another subtlety: the `WITH_CLEANUP` bytecode name is now, at least in 3.6, separated into `WITH_CLEANUP_START` and `WITH_CLEANUP_END` and so I've changed these in `dis.js`. The Batavia code handling this opcode in the VM code is currently commented out, so I've gone ahead and changed `WITH_CLEANUP` into `WITH_CLEANUP_START` _inside_ the commented-out code. 

Before too much more work is done, we should discuss whether this is the right approach or not.