### PR TITLE
Add `clear` method to List object

### DIFF
--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -659,6 +659,15 @@ List.prototype.pop = function(index) {
     return this.splice(index, 1)[0]
 }
 
+List.prototype.clear = function() {
+    if (arguments.length !== 0) {
+        throw new exceptions.TypeError.$pyclass(
+            'clear() takes no arguments (' + arguments.length + ' given)'
+        )
+    }
+    this.splice(0, this.length)
+}
+
 function validateIndexType(index) {
     var types = require('../types')
     if (!types.isinstance(index, types.Int)) {

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -348,6 +348,29 @@ class ListTests(TranspileTestCase):
             l.pop(I())
         """)
 
+    def test_clear_success(self):
+
+        self.assertCodeExecution("""
+            l = ["one", "two", 3]
+            l.clear()
+            print(l)
+        """)
+
+    def test_clear_args(self):
+
+        self.assertCodeExecution("""
+            l = ["one", "two", 3]
+            l.clear("invalid")
+            print(l)
+        """)
+
+    def test_clear_empty_list(self):
+
+        self.assertCodeExecution("""
+            l = []
+            l.clear()
+            print(l)
+        """)
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'


### PR DESCRIPTION
Summary:
Add stdlib implementation of `clear` to the List object.

Test Plan:
Add unit tests for empty list, call to `clear` with invalid arguments, and success case
Run tests in tests.datatypes.test_list.ListTests to check for regressions