### PR TITLE
Implement 'reversed' for custom __reversed__

### DIFF
--- a/batavia/builtins/reversed.js
+++ b/batavia/builtins/reversed.js
@@ -1,9 +1,12 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
+var callables = require('../core').callables
 
 function reversed(args, kwargs) {
     var iterable = args[0]
-    if (types.isinstance(iterable, [types.List, types.Tuple])) {
+    if (iterable.__reversed__) {
+        return callables.call_method(iterable, '__reversed__', [])
+    } else if (iterable.__len__ && iterable.__getitem__) {
         var new_iterable = iterable.slice(0)
         new_iterable.reverse()
         return new types.List(new_iterable)

--- a/tests/builtins/test_reversed.py
+++ b/tests/builtins/test_reversed.py
@@ -3,9 +3,19 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 class ReversedTests(TranspileTestCase):
     
-    def test_reverse_list(self):
+    def test_reversed_list(self):
         self.assertCodeExecution("""
             print(list(reversed([1,2,3])))
+        """)
+
+    def test_reversed_dunder_reversed(self):
+        self.assertCodeExecution("""
+            class Foo(object):
+                def __reversed__(self):
+                    return iter([1, 2, 3])
+                    
+            f = Foo()
+            print(list(reversed(f)))
         """)
 
 


### PR DESCRIPTION
[From the docs](https://docs.python.org/2/library/functions.html#reversed):

> **`reversed(seq)`**
Return a reverse iterator. `seq` must be an object which has a `__reversed__()` method or supports the sequence protocol (the `__len__()` method and the `__getitem__()` method with integer arguments starting at 0).