### PR TITLE
Implemented __len__ for some types and improved len() implementation

### DIFF
--- a/batavia/builtins/len.js
+++ b/batavia/builtins/len.js
@@ -1,6 +1,5 @@
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
-var types = require('../types')
 
 function len(args, kwargs) {
     if (!args || args.length !== 1 || args[0] === undefined) {
@@ -9,17 +8,11 @@ function len(args, kwargs) {
 
     var value = args[0]
 
-    if (types.isinstance(value, [types.Float, types.Int])) {
+    if (!args[0].__len__) {
         throw new exceptions.TypeError.$pyclass("object of type '" + type_name(value) + "' has no len()")
     }
 
-    // if (args[0].hasOwnProperty("__len__")) {
-        // TODO: Fix context of python functions calling with proper vm
-        // throw new exceptions.NotImplementedError.$pyclass('Builtin Batavia len function is not supporting __len__ implemented.');
-        // return args[0].__len__.apply(vm);
-    // }
-
-    return new types.Int(args[0].length)
+    return args[0].__len__()
 }
 len.__doc__ = 'len(object)\n\nReturn the number of items of a sequence or collection.'
 

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -106,6 +106,10 @@ Dict.prototype.toString = function() {
  * Type conversions
  **************************************************/
 
+Dict.prototype.__len__ = function() {
+    return this.size
+}
+
 Dict.prototype.__bool__ = function() {
     return this.size > 0
 }

--- a/batavia/types/FrozenSet.js
+++ b/batavia/types/FrozenSet.js
@@ -34,6 +34,10 @@ FrozenSet.prototype.toString = function() {
  * Type conversions
  **************************************************/
 
+FrozenSet.prototype.__len__ = function() {
+    return this.data.size
+}
+
 FrozenSet.prototype.__bool__ = function() {
     return this.data.__bool__()
 }

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -34,6 +34,10 @@ Set.prototype.toString = function() {
  * Type conversions
  **************************************************/
 
+Set.prototype.__len__ = function() {
+    return this.data.size
+}
+
 Set.prototype.__bool__ = function() {
     return this.data.__bool__()
 }

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -21,6 +21,10 @@ create_pyclass(Str, 'str', true)
  * Type conversions
  **************************************************/
 
+Str.prototype.__len__ = function() {
+    return this.length
+}
+
 Str.prototype.__bool__ = function() {
     return this.length > 0
 }

--- a/tests/builtins/test_len.py
+++ b/tests/builtins/test_len.py
@@ -9,15 +9,5 @@ class BuiltinLenFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["len"]
 
     not_implemented = [
-        'test_bool',
-        'test_bytes',
         'test_bytearray',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_frozenset',
-        'test_None',
-        'test_NotImplemented',
-        'test_set',
-        'test_slice',
     ]


### PR DESCRIPTION
The __len__ function was added for types that didn't already have one. The len() implementation was improved to explicitly check for the existence of a __len__ method as suggested by @freakboy3742.
Please take a look. 