### PR TITLE
Fix bug in Bool.js, change default for JSCleaner

### DIFF
--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -83,7 +83,7 @@ Bool.prototype.__ge__ = function(other) {
         } else {
             this_bool = 0.0
         }
-        return new types.Float(this_bool >= other.valueOf())
+        return new Bool(this_bool >= other.valueOf())
     } else if (types.isinstance(other, types.Int)) {
         return this.__int__().__ge__(other)
     } else if (types.isinstance(other, Bool)) {
@@ -115,7 +115,7 @@ Bool.prototype.__gt__ = function(other) {
         } else {
             this_bool = 0.0
         }
-        return new types.Float(this_bool > other.valueOf())
+        return new Bool(this_bool > other.valueOf())
     } else if (types.isinstance(other, types.Int)) {
         return this.__int__().__gt__(other)
     } else if (types.isinstance(other, Bool)) {
@@ -147,7 +147,7 @@ Bool.prototype.__le__ = function(other) {
         } else {
             this_bool = 0.0
         }
-        return new types.Float(this_bool <= other.valueOf())
+        return new Bool(this_bool <= other.valueOf())
     } else if (types.isinstance(other, types.Int)) {
         return this.__int__().__le__(other)
     } else if (types.isinstance(other, Bool)) {
@@ -179,7 +179,7 @@ Bool.prototype.__lt__ = function(other) {
         } else {
             this_bool = 0.0
         }
-        return new types.Float(this_bool < other.valueOf())
+        return new Bool(this_bool < other.valueOf())
     } else if (types.isinstance(other, types.Int)) {
         return this.__int__().__lt__(other)
     } else if (types.isinstance(other, Bool)) {

--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -197,7 +197,8 @@ Float.prototype.__neg__ = function() {
 }
 
 Float.prototype.__not__ = function() {
-    return new Float(!this.valueOf())
+    var types = require('../types')
+    return new types.Bool(!this.valueOf())
 }
 
 Float.prototype.__invert__ = function() {

--- a/batavia/types/StrUtils.js
+++ b/batavia/types/StrUtils.js
@@ -316,6 +316,7 @@ function _substitute(format, args) {
                     case ('bytes'):
                     case ('bytearray'):
                     case ('slice'):
+                    case ('bool'):
                         return bataviaType.__repr__()
 
                     case ('type'):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,8 +91,12 @@ class JavaScriptNormalizationTests(unittest.TestCase):
         )
 
     def test_bool(self):
-        self.assertNormalized('true', 'True')
-        self.assertNormalized('false', 'False')
+        self.assertNormalized(
+            'true', 'True', js_cleaner=JSCleaner(js_bool=True)
+        )
+        self.assertNormalized(
+            'true', 'True', js_cleaner=JSCleaner(js_bool=True)
+        )
 
     def test_float(self):
         self.assertNormalized('7.95089e-06', '7.95089e-6')
@@ -245,7 +249,7 @@ class JavaScriptBootstrapTests(TranspileTestCase):
         )
 
 class JSCleanerTests(TranspileTestCase):
-    cleaner = JSCleaner()
+    cleaner = JSCleaner(js_bool=True)
 
     def test_cleanse_err_msg(self):
         js_in = adjust("""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ import base64
 import contextlib
 from io import StringIO
 import importlib
-import inspect
 import os
 import py_compile
 import re
@@ -209,7 +208,7 @@ def transforms(**transform_args):
 
 
 class JSCleaner:
-    def __init__(self, err_msg = True, memory_ref = True, js_bool = True, decimal = True, float_exp = True, complex_num = True,
+    def __init__(self, err_msg = True, memory_ref = True, js_bool = False, decimal = True, float_exp = True, complex_num = True,
         high_precision_float = True, test_ref = True, custom = True):
 
         self.transforms = {
@@ -688,10 +687,10 @@ class TranspileTestCase(TestCase):
 
 
 class NotImplementedToExpectedFailure:
-    
+
     def _is_flakey(self):
         return self._testMethodName in getattr(self, "is_flakey", [])
-    
+
     def _is_not_implemented(self):
         '''
         A test is expected to fail if:
@@ -1354,7 +1353,7 @@ def _module_one_arg_func_test(name, module, f, examples, small_ints=False):
         actuals = [x for x in examples if abs(int(x)) < 8192]
 
     def func(self):
-        self.assertOneArgModuleFuction(
+        self.assertOneArgModuleFunction(
             name=name,
             module=module,
             func=f,
@@ -1366,7 +1365,7 @@ def _module_one_arg_func_test(name, module, f, examples, small_ints=False):
 
 def _module_two_arg_func_test(name, module, f,  examples, examples2):
     def func(self):
-        self.assertTwoArgModuleFuction(
+        self.assertTwoArgModuleFunction(
             name=name,
             module=module,
             func=f,
@@ -1384,7 +1383,9 @@ numerics = {'bool', 'float', 'int'}
 class ModuleFunctionTestCase(NotImplementedToExpectedFailure):
     numerics_only = False
 
-    def assertOneArgModuleFuction(self, name, module, func, x_values, substitutions):
+    def assertOneArgModuleFunction(
+        self, name, module, func, x_values, substitutions, **kwargs
+    ):
         self.assertCodeExecution(
             '##################################################\n'.join(
                 adjust("""
@@ -1411,9 +1412,12 @@ class ModuleFunctionTestCase(NotImplementedToExpectedFailure):
             "Error running %s module %s" % (module, name),
             substitutions=substitutions,
             run_in_function=False,
+            **kwargs
         )
 
-    def assertTwoArgModuleFuction(self, name, module, func, x_values, y_values, substitutions):
+    def assertTwoArgModuleFunction(
+        self, name, module, func, x_values, y_values, substitutions, **kwargs
+    ):
         self.assertCodeExecution(
             '##################################################\n'.join(
                 adjust("""
@@ -1443,6 +1447,7 @@ class ModuleFunctionTestCase(NotImplementedToExpectedFailure):
             "Error running %s module %s" % (module, name),
             substitutions=substitutions,
             run_in_function=False,
+            **kwargs
         )
 
     @classmethod


### PR DESCRIPTION
Bug in bool comparisons caused bool/float comparisons to return float.

Default behaviour of assertCodeExecution was to capitalize lowercase
occurences of "true" and "false" in output, which seems to serve no
purpose, but silence the above mentioned bug, and cause tests like
`assertCodeExecution("print('true')")` to fail.

Also very minor changes to ModuleFunctionTestCase including fixing
misspelled method name.