### PR TITLE
Remove conda installation instructions

### DIFF
--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -41,14 +41,6 @@ Then create a virtual environment and install Batavia into it:
     $ cd batavia
     $ pip install -e .
 
-*For those using anaconda*:
-
-.. code-block:: bash
-
-    $ cd batavia
-    $ conda create -n batavia-dev
-    $ source activate batavia-dev
-    $ pip install -e .
 
 Install Node.JS
 ^^^^^^^^^^^^^^^

--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -33,13 +33,6 @@ how to set this up are `on our Environment setup guide
    > activate
    > pip install -e .
 
- * For Anaconda users::
-
-   $ cd batavia
-   $ conda create -n batavia
-   $ source activate batavia
-   $ pip install -e .
-
 4. In addition, you need to install `Node.js <https://nodejs.org>`_. You need
    to have a recent version of Node; we test using v6.9.1. It's possible you
    might already have Node installed, so to check what version you have, run::


### PR DESCRIPTION
Based on troubleshooting from sprints, the python installation provided by conda doesn't include parts of the standard library, specifically related to testing. This means that the normal process for setting up a Batavia development environment cannot be followed since testing is a pivotal part of this.