### PR TITLE
A more complete ord builtin function

### DIFF
--- a/batavia/builtins/ord.js
+++ b/batavia/builtins/ord.js
@@ -5,27 +5,28 @@ var types = require('../types')
 
 function ord(args, kwargs) {
     if (arguments.length !== 2) {
-        throw new exceptions.BataviaError.$pyclass("Batavia calling convention not used.")
+        throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }
     if (kwargs && Object.keys(kwargs).length > 0) {
         throw new exceptions.TypeError.$pyclass("ord() doesn't accept keyword arguments")
     }
     if (!args || args.length !== 1) {
-        throw new exceptions.TypeError.$pyclass("ord() takes exactly one argument (" + args.length + " given)")
+        throw new exceptions.TypeError.$pyclass('ord() takes exactly one argument (' + args.length + ' given)')
     }
     var value = args[0]
     if (types.isinstance(value, [types.Str, types.Bytes, types.Bytearray])) {
-        var charLength = call_method(value, "__len__")
-        if (call_method(charLength, "__eq__", [new types.Int(1)])) {
-            if (types.isinstance(value, types.Str))
+        var charLength = call_method(value, '__len__')
+        if (call_method(charLength, '__eq__', [new types.Int(1)])) {
+            if (types.isinstance(value, types.Str)) {
                 return new types.Int(value.charCodeAt(0))
-            else
-                return call_method(value, "__getitem__", [new types.Int(0)])
+            } else {
+                return call_method(value, '__getitem__', [new types.Int(0)])
+            }
         } else {
-            throw new exceptions.TypeError.$pyclass("ord() expected a character, but string of length " + charLength + " found")
+            throw new exceptions.TypeError.$pyclass('ord() expected a character, but string of length ' + charLength + ' found')
         }
     } else {
-        throw new exceptions.TypeError.$pyclass("ord() expected string of length 1, but " + type_name(value) + " found")
+        throw new exceptions.TypeError.$pyclass('ord() expected string of length 1, but ' + type_name(value) + ' found')
     }
 }
 ord.__doc__ = 'ord(c) -> integer\n\nReturn the integer ordinal of a one-character string.'

--- a/batavia/builtins/ord.js
+++ b/batavia/builtins/ord.js
@@ -1,6 +1,32 @@
+var exceptions = require('../core').exceptions
+var type_name = require('../core').type_name
+var call_method = require('../core').callables.call_method
+var types = require('../types')
 
 function ord(args, kwargs) {
-    return args[0].charCodeAt(0)
+    if (arguments.length !== 2) {
+        throw new exceptions.BataviaError.$pyclass("Batavia calling convention not used.")
+    }
+    if (kwargs && Object.keys(kwargs).length > 0) {
+        throw new exceptions.TypeError.$pyclass("ord() doesn't accept keyword arguments")
+    }
+    if (!args || args.length !== 1) {
+        throw new exceptions.TypeError.$pyclass("ord() takes exactly one argument (" + args.length + " given)")
+    }
+    var value = args[0]
+    if (types.isinstance(value, [types.Str, types.Bytes, types.ByteArray])) {
+        var charLength = call_method(value, "__len__")
+        if (call_method(charLength, "__eq__", [new types.Int(1)])) {
+            if (types.isinstance(value, types.Str))
+                return new types.Str(value.charCodeAt(0))
+            else
+                return call_method(value, "__getitem__", [new types.Int(0)])
+        } else {
+            throw new exceptions.TypeError.$pyclass("ord() expected a character, but string of length " + charLength + " found")
+        }
+    } else {
+        throw new exceptions.TypeError.$pyclass("ord() expected string of length 1, but " + type_name(value) + " found")
+    }
 }
 ord.__doc__ = 'ord(c) -> integer\n\nReturn the integer ordinal of a one-character string.'
 

--- a/batavia/builtins/ord.js
+++ b/batavia/builtins/ord.js
@@ -14,7 +14,7 @@ function ord(args, kwargs) {
         throw new exceptions.TypeError.$pyclass("ord() takes exactly one argument (" + args.length + " given)")
     }
     var value = args[0]
-    if (types.isinstance(value, [types.Str, types.Bytes, types.ByteArray])) {
+    if (types.isinstance(value, [types.Str, types.Bytes, types.Bytearray])) {
         var charLength = call_method(value, "__len__")
         if (call_method(charLength, "__eq__", [new types.Int(1)])) {
             if (types.isinstance(value, types.Str))

--- a/batavia/builtins/ord.js
+++ b/batavia/builtins/ord.js
@@ -18,7 +18,7 @@ function ord(args, kwargs) {
         var charLength = call_method(value, "__len__")
         if (call_method(charLength, "__eq__", [new types.Int(1)])) {
             if (types.isinstance(value, types.Str))
-                return new types.Str(value.charCodeAt(0))
+                return new types.Int(value.charCodeAt(0))
             else
                 return call_method(value, "__getitem__", [new types.Int(0)])
         } else {

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -303,9 +303,14 @@ Bytes.prototype.__sub__ = function(other) {
 
 Bytes.prototype.__getitem__ = function(other) {
     var types = require('../types')
-    var builtins = require('../builtins')
 
-    return new types.Int(this.val[builtins.int(other).valueOf()])
+    if (types.isinstance(other, types.Slice)) {
+      throw new exceptions.NotImplementedError.$pyclass('Bytes.__getitem__ with slice has not been implemented')
+    }
+    if (!types.isinstance(other, types.Int)) {
+      throw new exceptions.TypeError.$pyclass('byte indices must be integers or slices, not ' + type_name(other))
+    }
+    return new types.Int(this.val[other.int32()])
 }
 
 Bytes.prototype.__lshift__ = function(other) {

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -305,10 +305,10 @@ Bytes.prototype.__getitem__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, types.Slice)) {
-      throw new exceptions.NotImplementedError.$pyclass('Bytes.__getitem__ with slice has not been implemented')
+        throw new exceptions.NotImplementedError.$pyclass('Bytes.__getitem__ with slice has not been implemented')
     }
     if (!types.isinstance(other, types.Int)) {
-      throw new exceptions.TypeError.$pyclass('byte indices must be integers or slices, not ' + type_name(other))
+        throw new exceptions.TypeError.$pyclass('byte indices must be integers or slices, not ' + type_name(other))
     }
     return new types.Int(this.val[other.int32()])
 }

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -498,7 +498,8 @@ Str.prototype.__ior__ = function(other) {
  **************************************************/
 
 Str.prototype.__len__ = function() {
-    return this.length
+    var types = require('../types')
+    return new types.Int(this.length)
 }
 
 Str.prototype.join = function(iter) {

--- a/tests/builtins/test_ord.py
+++ b/tests/builtins/test_ord.py
@@ -1,30 +1,53 @@
 from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+import unittest
+import string
 
 
 class OrdTests(TranspileTestCase):
-    pass
+    def test_ord_ascii(self):
+        tests = []
+        for char in string.ascii_letters:
+            tests.append("print(ord('%s'))" % char)
+            tests.append("print(ord(b'%s'))" % char)
+        self.assertCodeExecution("\n".join(tests))
+
+    def test_ord_unicode(self):
+        letters = ',!}12 中한πß≈ऋ㍿'
+        tests = []
+        for char in letters:
+            tests.append("print(ord('%s'))" % char)
+        self.assertCodeExecution("\n".join(tests))
+
+    @unittest.expectedFailure
+    def test_ord_emoji(self):
+        # Emojis have length of 2 in JavaScript since JS uses UTF-16
+        self.assertCodeExecution("""
+            try:
+                print(ord('🐝'))
+            except TypeError as e:
+                print(e)
+        """)
+
+    def test_ord_exceptins(self):
+        self.assertCodeExecution("""
+            try:
+                print(ord("bc"))
+            except TypeError as e:
+                print(e)
+            try:
+                print(ord(b"bc"))
+            except TypeError as e:
+                print(e)
+            try:
+                print(ord(""))
+            except TypeError as e:
+                print(e)
+        """)
 
 
 class BuiltinOrdFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     functions = ["ord"]
 
     not_implemented = [
-        'test_noargs',
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
+        'test_bytearray'
     ]


### PR DESCRIPTION
- Add argument checking in `ord` implementation
- Only accept `str`, `bytes` or `bytearray` with length 1
- Returns a `types.Int` object
- Add tests for `ord`

Additional patches:
- Return `types.Int` in `str.__len__` method
- Fix `bytes.__getitem__` method

Known problems:
- Unicode characters whose UTF-16 encoding is greater than 16 bits (e.g. emojis) are failed to handle