### PR TITLE
Builtin zip function and zip type

### DIFF
--- a/batavia/builtins/zip.js
+++ b/batavia/builtins/zip.js
@@ -1,29 +1,15 @@
+var exceptions = require('../core').exceptions
 var types = require('../types')
 
 function zip(args, kwargs) {
-    if (args === undefined) {
-        return new types.List()
+    if (args.length !== 2) {
+        throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
+    }
+    if (kwargs && Object.keys(kwargs).length > 0) {
+        throw new exceptions.TypeError.$pyclass('zip() does not take keyword arguments')
     }
 
-    var minLen = Math.min.apply(null, args.map(function(element) {
-        return element.length
-    }))
-
-    if (minLen === 0) {
-        return new types.List()
-    }
-
-    var result = new types.List()
-    for (var i = 0; i < minLen; i++) {
-        var sequence = []
-        for (var iterableObj = 0; iterableObj < args.length; iterableObj++) {
-            sequence.push(args[iterableObj][i])
-        }
-
-        result.push(new types.Tuple(sequence))
-    }
-
-    return result
+    return new types.Zip(args, kwargs)
 }
 zip.__doc__ = 'zip(iter1 [,iter2 [...]]) --> zip object\n\nReturn a zip object whose .__next__() method returns a tuple where\nthe i-th element comes from the i-th iterable argument.  The .__next__()\nmethod continues until the shortest iterable in the argument sequence\nis exhausted and then it raises StopIteration.'
 

--- a/batavia/builtins/zip.js
+++ b/batavia/builtins/zip.js
@@ -2,7 +2,7 @@ var exceptions = require('../core').exceptions
 var types = require('../types')
 
 function zip(args, kwargs) {
-    if (args.length !== 2) {
+    if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }
     if (kwargs && Object.keys(kwargs).length > 0) {

--- a/batavia/types.js
+++ b/batavia/types.js
@@ -36,6 +36,7 @@ types['Ellipsis'] = require('./types/Ellipsis')
 
 types['Filter'] = require('./types/Filter')
 types['Map'] = require('./types/Map')
+types['Zip'] = require('./types/Zip')
 
 types['Function'] = require('./types/Function')
 types['Method'] = require('./types/Method')

--- a/batavia/types/Zip.js
+++ b/batavia/types/Zip.js
@@ -44,6 +44,10 @@ Zip.prototype.__iter__ = function() {
 }
 
 Zip.prototype.__next__ = function() {
+    if (this._iterators.length === 0) {
+        throw new exceptions.StopIteration.$pyclass()
+    }
+
     var Tuple = require('./Tuple')
 
     var values = []

--- a/batavia/types/Zip.js
+++ b/batavia/types/Zip.js
@@ -1,0 +1,64 @@
+var PyObject = require('../core').Object
+var callables = require('../core').callables
+var exceptions = require('../core').exceptions
+var create_pyclass = require('../core').create_pyclass
+
+/*************************************************************************
+ * A Python zip builtin is a type
+ *************************************************************************/
+
+function Zip(args, kwargs) {
+    var builtins = require('../builtins')
+    PyObject.call(this)
+
+    this._iterables = args
+    this._iterators = []
+
+    for (var i = 0, n = 1; i < args.length; i++, n++) {
+        try {
+            this._iterators.push(builtins.iter([this._iterables[i]], null))
+        } catch (e) {
+            if (e instanceof exceptions.TypeError.$pyclass) {
+                throw new exceptions.TypeError.$pyclass('zip argument #' + n + ' must support iteration')
+            }
+        }
+    }
+}
+
+create_pyclass(Zip, 'zip')
+
+/**************************************************
+ * Javascript compatibility methods
+ **************************************************/
+
+Zip.prototype.toString = function() {
+    return this.__str__()
+}
+
+/**************************************************
+ * Type conversions
+ **************************************************/
+
+Zip.prototype.__iter__ = function() {
+    return this
+}
+
+Zip.prototype.__next__ = function() {
+    var Tuple = require('./Tuple')
+
+    var values = []
+    for (var i = 0; i < this._iterators.length; i++) {
+        values.push(callables.call_method(this._iterators[i], '__next__'))
+    }
+    return new Tuple(values)
+}
+
+Zip.prototype.__str__ = function() {
+    return '<zip object at 0x99999999>'
+}
+
+/**************************************************
+ * Module exports
+ **************************************************/
+
+module.exports = Zip

--- a/tests/builtins/test_zip.py
+++ b/tests/builtins/test_zip.py
@@ -1,0 +1,71 @@
+from .. utils import TranspileTestCase, BuiltinTwoargFunctionTestCase
+
+from unittest import expectedFailure
+
+
+class ZipTests(TranspileTestCase):
+
+    def test_empty(self):
+        self.assertCodeExecution("""
+            x = zip()
+            try:
+                next(x)
+            except Exception as e:
+                print(e)
+        """)
+
+    def test_one_iterable(self):
+        self.assertCodeExecution("""
+            x = zip([1, 3, 5])
+            print(type(x))
+            print(type(iter(x)))
+            print(x.__next__())
+            print(next(x))
+            print(next(x))
+            try:
+                next(x)
+            except Exception as e:
+                print(e)
+        """)
+
+    def test_two_iterables(self):
+        self.assertCodeExecution("""
+            x = zip([3, 4, 5], [10, 2, 5])
+            for item in x:
+                print(item)
+            try:
+                next(x)
+            except Exception as e:
+                print(e)
+        """)
+
+    def test_transcendental(self):
+        template = """
+            x = zip(%s)
+            for item in x:
+                print(item)
+            try:
+                next(x)
+            except Exception as e:
+                print(e)
+        """
+        test_cases = [
+            ['"hello"', '"world"'],
+            ['[1, 2, 3]', '[5, 4]'],
+            ['[]', '[1, 2, 3]'],
+            ['[1, 2, 3]', '[]'],
+            ['(4, 5)', '[1, 2, 3]'],
+            ['(1, 2, 3, 4)', '(5, 6)', '(3, 4, 5)'],
+            ['"string"', '("this", "is", "a", "tuple")'],
+            ['[True, 5.5, (1, 2)]', 'b"hello"', '(None, (float("inf"), "s"), range(10))'],
+        ]
+
+        code = '\n'.join(template % ', '.join(inputs) for inputs in test_cases)
+
+        self.assertCodeExecution(code)
+
+
+class BuiltinFilterFunctionTests(BuiltinTwoargFunctionTestCase, TranspileTestCase):
+    functions = ["zip"]
+
+    not_implemented = []

--- a/tests/builtins/test_zip.py
+++ b/tests/builtins/test_zip.py
@@ -1,7 +1,5 @@
 from .. utils import TranspileTestCase, BuiltinTwoargFunctionTestCase
 
-from unittest import expectedFailure
-
 
 class ZipTests(TranspileTestCase):
 
@@ -54,6 +52,7 @@ class ZipTests(TranspileTestCase):
             ['[1, 2, 3]', '[5, 4]'],
             ['[]', '[1, 2, 3]'],
             ['[1, 2, 3]', '[]'],
+            ['[]', '()'],
             ['(4, 5)', '[1, 2, 3]'],
             ['(1, 2, 3, 4)', '(5, 6)', '(3, 4, 5)'],
             ['"string"', '("this", "is", "a", "tuple")'],
@@ -61,7 +60,24 @@ class ZipTests(TranspileTestCase):
         ]
 
         code = '\n'.join(template % ', '.join(inputs) for inputs in test_cases)
+        self.assertCodeExecution(code)
 
+    def test_invalid_inputs(self):
+        template = """
+            try:
+                x = zip(%s)
+            except TypeError as e:
+                print(e)
+        """
+        test_cases = [
+            ['3'],
+            ['1.5'],
+            ['[1, 2, 3]', 'False'],
+            ['"string"', 'None'],
+            ['"valid"', '("o", "k")', '500'],
+        ]
+
+        code = '\n'.join(template % ', '.join(inputs) for inputs in test_cases)
         self.assertCodeExecution(code)
 
 


### PR DESCRIPTION
- Add builtin type `zip`
- Create a `Zip` object when calling `zip` builtin function, instead of return a list of tuples
- Test cases included