### PR TITLE
fix js2py for object -> dict

### DIFF
--- a/batavia/builtins/hash.js
+++ b/batavia/builtins/hash.js
@@ -1,8 +1,8 @@
 var exceptions = require('../core').exceptions
 var type_name = require('../core').type_name
-var types = require('../types')
 
 function hash(args, kwargs) {
+    var types = require('../types')
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used.')
     }

--- a/batavia/types.js
+++ b/batavia/types.js
@@ -161,7 +161,7 @@ types.js2py = function(arg) {
                 var dict = new types.Dict()
                 for (var k in arg) {
                     if (arg.hasOwnProperty(k)) {
-                        dict.__setitem__(k, arg[k])
+                        dict.__setitem__(types.js2py(k), types.js2py(arg[k]))
                     }
                 }
                 return dict

--- a/batavia/types.js
+++ b/batavia/types.js
@@ -150,7 +150,10 @@ types.js2py = function(arg) {
         case 'object':
             if (arg === null || arg === types.NoneType) {
                 return null
-            } else if (arg.__class__ !== null && arg.__class__.__name__) {
+            } else if (
+                arg.__class__ !== undefined &&
+                arg.__class__ !== null &&
+                arg.__class__.__name__) {
                 // already a Python object
                 return arg
             } else {
@@ -158,7 +161,7 @@ types.js2py = function(arg) {
                 var dict = new types.Dict()
                 for (var k in arg) {
                     if (arg.hasOwnProperty(k)) {
-                        dict[types.js2py(k)] = types.js2py(arg[k])
+                        dict.__setitem__(k, arg[k])
                     }
                 }
                 return dict

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,116 @@
 import unittest
 from . utils import TranspileTestCase
 
+
 class TestJs2Py(TranspileTestCase):
-    pass
+    def js2py_test(self, decl, check, result):
+        self.assertJavaScriptExecution(
+            """
+            from harness import testfunc
+
+            val = testfunc()
+            %s
+
+            print("Done.")
+            """ % check,
+            js={
+                'harness': """
+                var harness = function(mod) {
+
+                    mod.testfunc = function() {
+                        %s
+                        return batavia.types.js2py(obj)
+                    };
+
+                    return mod;
+                }({});
+                """ % decl
+            },
+            out=result,
+        )
+
+    def test_bool(self):
+        self.js2py_test(
+            decl="""
+            var obj = 42;
+            """,
+            check="""
+            print('Val is a %s = %s' % (type(val), val))
+            """,
+            result="""
+            Val is a <class 'int'> = 42
+            Done.
+            """
+        )
+
+    def test_int(self):
+        self.js2py_test(
+            decl="""
+            var obj = 42;
+            """,
+            check="""
+            print('Val is a %s = %s' % (type(val), val))
+            """,
+            result="""
+            Val is a <class 'int'> = 42
+            Done.
+            """
+        )
+
+    def test_float(self):
+        self.js2py_test(
+            decl="""
+            var obj = 42;
+            """,
+            check="""
+            print('Val is a %s = %s' % (type(val), val))
+            """,
+            result="""
+            Val is a <class 'int'> = 42
+            Done.
+            """
+        )
+
+    def test_list(self):
+        self.js2py_test(
+            decl="""
+            var obj = [true, 42, 3.14159, 'value1', [false, 37]];
+            """,
+            check="""
+            print('Val is a %s = %s' % (type(val), val))
+            """,
+            result="""
+            Val is a <class 'list'> = [True, 42, 3.14159, 'value1', [False, 37]]
+            Done.
+            """
+        )
+
+    def test_dict(self):
+        self.js2py_test(
+            decl="""
+                var obj = {
+                    'bool_value': true,
+                    'integer_value': 42,
+                    'float_value': 3.14159,
+                    'string_value': 'value1',
+                    'list_value': [false, 37]
+                };
+            """,
+            check="""
+            print('Val is a %s, with %s items' % (type(val), len(val)))
+            print('boolean:', val['bool_value'])
+            print('integer:', val['integer_value'])
+            print('float:', val['float_value'])
+            print('string:', val['string_value'])
+            print('list:', val['list_value'])
+            """,
+            result="""
+            Val is a <class 'dict'>, with 5 items
+            boolean: True
+            integer: 42
+            float: 3.14159
+            string: value1
+            list: [False, 37]
+            Done.
+            """
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,5 @@
+import unittest
+from utils import TranspileTestCase
+
+class TestJs2Py(TranspileTestCase):
+    pass

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,5 @@
 import unittest
-from utils import TranspileTestCase
+from . utils import TranspileTestCase
 
 class TestJs2Py(TranspileTestCase):
     pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -578,6 +578,9 @@ class TranspileTestCase(TestCase):
             ''.format(type(main_code))
         )
 
+        # print("MAIN CODE:")
+        # print(main_code)
+
         if not python_exists:
             if isinstance(main_code, str):
                 py_filename = os.path.join(self.temp_dir, 'test.py')
@@ -672,6 +675,10 @@ class TranspileTestCase(TestCase):
                 )
             )
 
+        # print("JS CODE:")
+        # with open(os.path.join(self.temp_dir, 'test.js')) as js_file:
+        #     print(js_file.read())
+
         proc = subprocess.Popen(
             ['node', 'test.js'] + args,
             stdin=subprocess.PIPE,
@@ -688,10 +695,10 @@ class TranspileTestCase(TestCase):
 
 
 class NotImplementedToExpectedFailure:
-    
+
     def _is_flakey(self):
         return self._testMethodName in getattr(self, "is_flakey", [])
-    
+
     def _is_not_implemented(self):
         '''
         A test is expected to fail if:


### PR DESCRIPTION
 - require `types` inside of hash function
 - use `__setitem__` in js2py rather than tacking on a new attr