### PR TITLE
Simple change for testing bytes and bytearray multiplication

### DIFF
--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -293,7 +293,7 @@ function __mul__(x, y, inplace) {
         }
     } else if (types.isinstance(y, types.Complex)) {
         return new Complex(x.real * y.real - x.imag * y.imag, x.real * y.imag + x.imag * y.real)
-    } else if (types.isinstance(y, [types.List, types.Str, types.Tuple])) {
+    } else if (types.isinstance(y, [types.List, types.Str, types.Tuple, types.Bytearray, types.Bytes])) {
         throw new exceptions.TypeError.$pyclass("can't multiply sequence by non-int of type 'complex'")
     } else {
         var prefix

--- a/tests/datatypes/test_complex.py
+++ b/tests/datatypes/test_complex.py
@@ -35,9 +35,6 @@ class BinaryComplexOperationTests(BinaryOperationTestCase, TranspileTestCase):
         # Python differences
         # TODO: re-implement the Python float printing function.
 
-        'test_multiply_bytearray',
-        'test_multiply_bytes',
-
         'test_power_complex',
         'test_power_float',
         'test_power_int',
@@ -48,9 +45,6 @@ class InplaceComplexOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'complex'
 
     not_implemented = [
-
-        'test_multiply_bytearray',
-        'test_multiply_bytes',
 
         'test_power_bool',
         'test_power_bytearray',


### PR DESCRIPTION
Adding correct exception messages (bytearray and bytes should raise the same exception, with the same message, as list, tuple, string for complex multiplication). First PR here, so any feedback is appreciated.