### PR TITLE
Changed directory during Windows venv setup (docs)

### DIFF
--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -29,9 +29,8 @@ how to set this up are `on our Environment setup guide
  * For Windows::
 
    > virtualenv --python=c:\python34\python.exe venv
-   > cd venv\Scripts
-   > activate
-   > cd ..\..\batavia
+   > venv\Scripts\activate
+   > cd batavia
    > pip install -e .
 
 4. In addition, you need to install `Node.js <https://nodejs.org>`_. You need

--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -31,6 +31,7 @@ how to set this up are `on our Environment setup guide
    > virtualenv --python=c:\python34\python.exe venv
    > cd venv\Scripts
    > activate
+   > cd ..\..\batavia
    > pip install -e .
 
 4. In addition, you need to install `Node.js <https://nodejs.org>`_. You need


### PR DESCRIPTION
After 'activate'-ing the venv, you're still in ...\pybee\venv\Scripts.
Need to move back to ...\batavia in order to pip install -e . (otherwise you get 'Directory '.' is not installable. File 'setup.py' not found.')