### PR TITLE
fix generated testnames for json module not valid python identifiers

### DIFF
--- a/tests/modules/test_json.py
+++ b/tests/modules/test_json.py
@@ -48,12 +48,12 @@ class JSONEncoderTests(ModuleFunctionTestCase, TranspileTestCase):
         """)
 
     not_implemented = [
-        'test_json_JSONEncoder().encode_dict',   # fails due to dict ordering
-        'test_json_JSONEncoder().encode_class',  # fails due to class __str__
+        'test_json_JSONEncoder__encode_dict',   # fails due to dict ordering
+        'test_json_JSONEncoder__encode_class',  # fails due to class __str__
     ]
 
 
-JSONEncoderTests.add_one_arg_tests('json', ['JSONEncoder().encode'])
+JSONEncoderTests.add_one_arg_tests('json', ['JSONEncoder__encode'])
 
 
 class DumpsTests(ModuleFunctionTestCase, TranspileTestCase):


### PR DESCRIPTION
Some of the tests generated in `tests/modules/test_json.py` produced test cases with names that are not valid Python identifiers; this breaks tools such as `cricket` which attempt to load and manipulate tests based on import paths.  This fixes #585 and is relevant to pybee/cricket#39.

