### PR TITLE
Fix bug with truth value testing of Python objects

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1542,7 +1542,7 @@ VirtualMachine.prototype.byte_JUMP_ABSOLUTE = function(jump) {
 VirtualMachine.prototype.byte_POP_JUMP_IF_TRUE = function(jump) {
     var val = this.pop()
     if (val.__bool__ !== undefined) {
-        val = val.__bool__()
+        val = val.__bool__().valueOf()
     }
 
     if (val) {
@@ -1553,7 +1553,7 @@ VirtualMachine.prototype.byte_POP_JUMP_IF_TRUE = function(jump) {
 VirtualMachine.prototype.byte_POP_JUMP_IF_FALSE = function(jump) {
     var val = this.pop()
     if (val.__bool__ !== undefined) {
-        val = val.__bool__()
+        val = val.__bool__().valueOf()
     }
 
     if (!val) {
@@ -1564,7 +1564,7 @@ VirtualMachine.prototype.byte_POP_JUMP_IF_FALSE = function(jump) {
 VirtualMachine.prototype.byte_JUMP_IF_TRUE_OR_POP = function(jump) {
     var val = this.top()
     if (val.__bool__ !== undefined) {
-        val = val.__bool__()
+        val = val.__bool__().valueOf()
     }
 
     if (val) {
@@ -1577,7 +1577,7 @@ VirtualMachine.prototype.byte_JUMP_IF_TRUE_OR_POP = function(jump) {
 VirtualMachine.prototype.byte_JUMP_IF_FALSE_OR_POP = function(jump) {
     var val = this.top()
     if (val.__bool__ !== undefined) {
-        val = val.__bool__()
+        val = val.__bool__().valueOf()
     }
 
     if (!val) {

--- a/tests/structures/test_if_elif_else.py
+++ b/tests/structures/test_if_elif_else.py
@@ -247,3 +247,19 @@ class IfElifElseTests(TranspileTestCase):
                 else:
                     y = 37
             """, run_in_function=False)
+
+    def test_truth_value_testing(self):
+        self.assertCodeExecution("""
+            def foo():
+                return None
+
+            if foo():
+                print('true')
+            else:
+                print('false')
+
+            if not foo():
+                print('true')
+            else:
+                print('false')
+        """)

--- a/tests/structures/test_or_and.py
+++ b/tests/structures/test_or_and.py
@@ -1,0 +1,25 @@
+from ..utils import TranspileTestCase
+
+
+class OrTests(TranspileTestCase):
+    def test_simple(self):
+        self.assertCodeExecution("""
+            print(False or 'yes')
+        """)
+
+    def test_truth_value_testing(self):
+        self.assertCodeExecution("""
+            print(None or 'yes')
+        """)
+
+
+class AndTests(TranspileTestCase):
+    def test_simple(self):
+        self.assertCodeExecution("""
+            print(True and 'yes')
+        """)
+
+    def test_truth_value_testing(self):
+        self.assertCodeExecution("""
+            print(None and 'yes')
+        """)


### PR DESCRIPTION
This bug caused objects other than `False` to evaluate to true
inside `if` conditions or boolean operators