### PR TITLE
Implement opcode GET_YIELD_FROM_ITER as GET_ITER

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -505,6 +505,9 @@ VirtualMachine.prototype.build_dispatch_table = function() {
             }
         } else {
             // dispatch
+            if (opcode === 69) {
+                opname = 'GET_YIELD_FROM_ITER'
+            }
             var bytecode_fn = vm['byte_' + opname]
             if (bytecode_fn) {
                 return bytecode_fn
@@ -1846,6 +1849,14 @@ VirtualMachine.prototype.byte_RETURN_VALUE = function() {
 VirtualMachine.prototype.byte_YIELD_VALUE = function() {
     this.return_value = this.pop()
     return 'yield'
+}
+
+VirtualMachine.prototype.byte_GET_YIELD_FROM_ITER = function() {
+    // This should first check if TOS is a coroutine and if so
+    // only allow another coroutine to 'yield from' it
+    // otherwise replace TOS with iter(TOS)
+    // For now, coroutines are not supported in Batavia, so this will do
+    return this.byte_GET_ITER()
 }
 
 VirtualMachine.prototype.byte_YIELD_FROM = function() {

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -505,9 +505,6 @@ VirtualMachine.prototype.build_dispatch_table = function() {
             }
         } else {
             // dispatch
-            if (opcode === 69) {
-                opname = 'GET_YIELD_FROM_ITER'
-            }
             var bytecode_fn = vm['byte_' + opname]
             if (bytecode_fn) {
                 return bytecode_fn

--- a/batavia/modules/dis.js
+++ b/batavia/modules/dis.js
@@ -112,6 +112,9 @@ def_binary_op('BINARY_OR', 66)
 def_inplace_op('INPLACE_POWER', 67)
 def_op('GET_ITER', 68)
 
+// introduced in Python 3.5+
+def_op('GET_YIELD_FROM_ITER', 69)
+
 def_op('PRINT_EXPR', 70)
 def_op('LOAD_BUILD_CLASS', 71)
 def_op('YIELD_FROM', 72)

--- a/beekeeper.yml
+++ b/beekeeper.yml
@@ -12,15 +12,16 @@ pull_request:
         task: batavia-py34
         name: Smoke build (Python 3.4)
         profile: hi-cpu
-    # - full-test:
-    #     subtasks:
-    #         - py3.5:
-    #             name: Python 3.5 tests
-    #             task: batavia-py35
+    - full-test:
+        subtasks:
+            - py3.5:
+                name: Python 3.5 tests
+                task: batavia-py35
+                critical: False
     #         - py3.6:
     #             name: Python 3.6 tests
     #             task: batavia-py36
-    #     profile: hi-cpu
+        profile: hi-cpu
 push:
     - smoke-test:
         task: py34


### PR DESCRIPTION
Re issue #598 

GET_YIELD_FROM_ITER differs from GET_ITER only if it encounters a
coroutine, but Batavia doesn't have asyncio yet.