### PR TITLE
Use venv instead of virtualenv and py on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Check your python3 version first.  If it's pointing to version 3.6, replace ``$(
 below with the path to your Python 3.4 or 3.5 installation. ::
 
 $ python3 --version
-$ virtualenv --python=$(which python3) venv
+$ python3 -m venv venv
 $ . venv/bin/activate
 $ cd batavia
 $ pip install -e .
@@ -79,10 +79,10 @@ Windows
 
 Type in the following commands in your terminal ::
 
-> virtualenv venv
-> venv\Scripts\activate
-> cd batavia
-> pip install -e .
+    > py -3 -m venv venv
+    > venv\Scripts\activate
+    > cd batavia
+    > pip install -e .
 
 
 3. Install `Node.js <https://nodejs.org>`_.

--- a/docs/community/contributing.rst
+++ b/docs/community/contributing.rst
@@ -18,7 +18,7 @@ instead of using the official PyBee repository, you'll be using your own
 Github fork.
 
 As with the getting started guide, these instructions will assume that you
-have Python 3.4, and have virtualenv available for use.
+have Python 3.4.
 
 Batavia codebase
 ^^^^^^^^^^^^^^^^
@@ -36,8 +36,8 @@ Then create a virtual environment and install Batavia into it:
 
 .. code-block:: bash
 
-    $ virtualenv -p $(which python3.4) env
-    $ . env/bin/activate
+    $ python3.4 -m venv venv
+    $ . venv/bin/activate
     $ cd batavia
     $ pip install -e .
 

--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -21,14 +21,14 @@ how to set this up are `on our Environment setup guide
 
  * For Linux, MacOS::
 
-   $ virtualenv --python=$(which python3) venv
+   $ python3.4 -m venv venv
    $ . venv/bin/activate
    $ cd batavia
    $ pip install -e .
 
  * For Windows::
 
-   > virtualenv --python=c:\python34\python.exe venv
+   > py -3.4 -m venv venv
    > venv\Scripts\activate
    > cd batavia
    > pip install -e .


### PR DESCRIPTION
Changes:

- Use `python -m venv` instead of `virtualenv -p $(which python)` (similar to pybee/voc#608)
- Instead of using full Python path on Windows, use `py -3` ([see here](https://docs.python.org/3.4/using/windows.html?highlight=windows#from-the-command-line))

I kept `python3` and `python3.4` references as-is. Maybe all should be updated to `python3.5`? Or does it work on 3.6 yet? I can change those in a future PR if needed.