### PR TITLE
Update existing PowTests

### DIFF
--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -17,8 +17,13 @@ function pow(args, kwargs) {
 
         if (!types.isinstance(x, types.Int) ||
             !types.isinstance(y, types.Int) ||
-            !types.isinstance(y, types.Int)) {
-            throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
+            !types.isinstance(z, types.Int)) {
+            var error = 'pow() 3rd argument not allowed unless all arguments are integers'
+            if (y < 0 && z < 0) {
+                throw new exceptions.ValueError.$pyclass(error)
+            } else {
+                throw new exceptions.TypeError.$pyclass(error)
+            }
         }
         if (y < 0) {
             // When 3 arguments and y is negative

--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -18,10 +18,12 @@ function pow(args, kwargs) {
         if (!types.isinstance(x, types.Int) ||
             !types.isinstance(y, types.Int) ||
             !types.isinstance(y, types.Int)) {
-            throw new exceptions.TypeError.$pyclass('pow() requires all arguments be integers when 3 arguments are present')
+            // throw new exceptions.TypeError.$pyclass('pow() requires all arguments be integers when 3 arguments are present')
+            throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {
-            throw new exceptions.TypeError.$pyclass('Builtin Batavia does not support negative exponents')
+            // When 3 arguments and y is negative
+            throw new exceptions.ValueError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
         }
         if (y === 0) {
             return 1

--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -18,7 +18,6 @@ function pow(args, kwargs) {
         if (!types.isinstance(x, types.Int) ||
             !types.isinstance(y, types.Int) ||
             !types.isinstance(y, types.Int)) {
-            // throw new exceptions.TypeError.$pyclass('pow() requires all arguments be integers when 3 arguments are present')
             throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
         }
         if (y < 0) {

--- a/builtins/pow.js
+++ b/builtins/pow.js
@@ -1,0 +1,53 @@
+var exceptions = require('../core').exceptions
+var types = require('../types')
+
+function pow(args, kwargs) {
+    var x, y, z
+    if (!args) {
+        throw new exceptions.TypeError.$pyclass('pow expected at least 2 arguments, got 0')
+    }
+    if (args.length === 2) {
+        x = args[0]
+        y = args[1]
+        return x.__pow__(y)
+    } else if (args.length === 3) {
+        x = args[0]
+        y = args[1]
+        z = args[2]
+
+        if (!types.isinstance(x, types.Int) ||
+            !types.isinstance(y, types.Int) ||
+            !types.isinstance(y, types.Int)) {
+            // throw new exceptions.TypeError.$pyclass('pow() requires all arguments be integers when 3 arguments are present')
+            throw new exceptions.TypeError.$pyclass('pow() 3rd argument not allowed unless all arguments are integers')
+        }
+        if (y < 0) {
+            // When 3 arguments and y is negative
+            throw new exceptions.ValueError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
+        }
+        if (y === 0) {
+            return 1
+        }
+        if (z === 1) {
+            return 0
+        }
+
+        // right-to-left exponentiation to reduce memory and time
+        // See https://en.wikipedia.org/wiki/Modular_exponentiation#Right-to-left_binary_method
+        var result = 1
+        var base = x % z
+        while (y > 0) {
+            if ((y & 1) === 1) {
+                result = (result * base) % z
+            }
+            y >>= 1
+            base = (base * base) % z
+        }
+        return result
+    } else {
+        throw new exceptions.TypeError.$pyclass('pow expected at least 2 arguments, got ' + args.length)
+    }
+}
+pow.__doc__ = 'pow(x, y[, z]) -> number\n\nWith two arguments, equivalent to x**y.  With three arguments,\nequivalent to (x**y) % z, but may be more efficient (e.g. for ints).'
+
+module.exports = pow

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from .. utils import TranspileTestCase, BuiltinFunctionTestCase, BuiltinTwoargFunctionTestCase
 
 

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -12,7 +12,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expectedFailure
     def test_int_neg_y_pos_z(self):
         self.assertCodeExecution("""
             x = 3
@@ -21,7 +20,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expectedFailure
     def test_int_neg_y_neg_z(self):
         self.assertCodeExecution("""
             x = 3
@@ -30,7 +28,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expectedFailure
     def test_float_x_with_z(self):
         self.assertCodeExecution("""
             x = 3.3
@@ -39,7 +36,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
             """)
 
-    @expectedFailure
     def test_float_y_with_z(self):
         self.assertCodeExecution("""
             x = 3
@@ -48,7 +44,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
             """)
 
-    @expectedFailure
     def test_float(self):
         self.assertCodeExecution("""
             x = 3.3
@@ -57,7 +52,6 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
-    @expectedFailure
     def test_float_neg_y_with_z(self):
         self.assertCodeExecution("""
             x = 3.3


### PR DESCRIPTION
This PR should remove the need for `@expectedFailure` for the six existing tests in `tests/builtins/test_pow.py` by raising the correct Python exception. 

The exception message for a `pow()` with non-integer looks like it might be valid for another version of Python? On v3.5.2, this change fixes it. 