### PR TITLE
Corrected exception for dict mul class.

### DIFF
--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -299,7 +299,8 @@ Dict.prototype.__mul__ = function(other) {
         types.Bool, types.Dict, types.Float,
         types.JSDict, types.Int, types.NoneType,
         types.Slice, types.Set, types.FrozenSet,
-        types.NotImplementedType, types.Complex, types.Range])) {
+        types.NotImplementedType, types.Complex, types.Range,
+        types.Type])) {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for *: 'dict' and '" + type_name(other) + "'")
     } else {
         throw new exceptions.TypeError.$pyclass("can't multiply sequence by non-int of type 'dict'")

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -265,8 +265,6 @@ class BinaryDictOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'dict'
 
     not_implemented = [
-        'test_multiply_class',
-
         'test_subscr_class',
         'test_subscr_NotImplemented'
     ]


### PR DESCRIPTION
I am not 100% sure about how JS, and managed to get the test to pass by adding the ``types.Type`` to the types which unsupported, rather than the Can't multiply exception text.
This was purely based on the error being ``can't multiply sequence by non-int of type 'dict'`` instead of ``unsupported operand type(s) for *: 'dict' and 'type'``.
Will be happier to see if ALL tests still pass.