### PR TITLE
Tr 46 test add complex

### DIFF
--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -196,7 +196,13 @@ Bytes.prototype.__div__ = function(other) {
 }
 
 Bytes.prototype.__floordiv__ = function(other) {
-    throw new exceptions.NotImplementedError.$pyclass('Bytes.__floordiv__ has not been implemented')
+    var types = require('../types')
+
+    if (types.isinstance(other, [types.Complex])) {
+        throw new exceptions.TypeError.$pyclass("can't take floor of complex number.")
+    } else {
+        throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for //: 'bytes' and '" + type_name(other) + "'")
+    }
 }
 
 Bytes.prototype.__truediv__ = function(other) {
@@ -338,7 +344,13 @@ Bytes.prototype.__or__ = function(other) {
  **************************************************/
 
 Bytes.prototype.__ifloordiv__ = function(other) {
-    throw new exceptions.NotImplementedError.$pyclass('Bytes.__ifloordiv__ has not been implemented')
+    var types = require('../types')
+    
+    if (types.isinstance(other, [types.Complex])) {
+        throw new exceptions.TypeError.$pyclass("can't take floor of complex number.")
+    } else {
+        throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for //=: 'bytes' and '" + type_name(other) + "'")
+    }
 }
 
 Bytes.prototype.__itruediv__ = function(other) {

--- a/tests/builtins/test_ascii.py
+++ b/tests/builtins/test_ascii.py
@@ -16,5 +16,4 @@ class BuiltinAsciiFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_NotImplemented',
     ]

--- a/tests/builtins/test_dict.py
+++ b/tests/builtins/test_dict.py
@@ -11,15 +11,9 @@ class BuiltinDictFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_bytearray',
         'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_float',
         'test_frozenset',
-        'test_None',
-        'test_NotImplemented',
         'test_range',
         'test_set',
-        'test_slice',
         'test_str',
     ]
 

--- a/tests/builtins/test_frozenset.py
+++ b/tests/builtins/test_frozenset.py
@@ -14,6 +14,4 @@ class BuiltinFrozensetFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
         'test_bytes',
         'test_dict',
         'test_range',
-        'test_str',
-        'test_tuple',
     ]

--- a/tests/builtins/test_print.py
+++ b/tests/builtins/test_print.py
@@ -81,5 +81,4 @@ class BuiltinPrintFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_NotImplemented',
     ]

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -19,5 +19,4 @@ class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_noargs',
         'test_class',
-        'test_NotImplemented',
     ]

--- a/tests/builtins/test_slice.py
+++ b/tests/builtins/test_slice.py
@@ -34,5 +34,4 @@ class BuiltinSliceFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_class',
-        'test_NotImplemented',
     ]

--- a/tests/builtins/test_str.py
+++ b/tests/builtins/test_str.py
@@ -14,5 +14,4 @@ class BuiltinStrFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_noargs',
         'test_class',
-        'test_NotImplemented',
     ]

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -134,24 +134,6 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         'test_eq_bytearray',
 
-        'test_floor_divide_bool',
-        'test_floor_divide_bytearray',
-        'test_floor_divide_bytes',
-        'test_floor_divide_class',
-        'test_floor_divide_complex',
-        'test_floor_divide_dict',
-        'test_floor_divide_float',
-        'test_floor_divide_frozenset',
-        'test_floor_divide_int',
-        'test_floor_divide_list',
-        'test_floor_divide_None',
-        'test_floor_divide_NotImplemented',
-        'test_floor_divide_range',
-        'test_floor_divide_set',
-        'test_floor_divide_slice',
-        'test_floor_divide_str',
-        'test_floor_divide_tuple',
-
         'test_ge_bytearray',
 
         'test_gt_bytearray',
@@ -277,7 +259,7 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_subtract_NotImplemented',
         'test_subtract_range',
         'test_subtract_slice',
-        
+
         'test_true_divide_bytearray',
         'test_true_divide_class',
         'test_true_divide_complex',
@@ -285,7 +267,7 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_true_divide_NotImplemented',
         'test_true_divide_range',
         'test_true_divide_slice',
-        
+
 
         'test_xor_bool',
         'test_xor_bytearray',
@@ -346,24 +328,6 @@ class InplaceBytesOperationTests(InplaceOperationTestCase, TranspileTestCase):
         'test_and_slice',
         'test_and_str',
         'test_and_tuple',
-
-        'test_floor_divide_bool',
-        'test_floor_divide_bytearray',
-        'test_floor_divide_bytes',
-        'test_floor_divide_class',
-        'test_floor_divide_complex',
-        'test_floor_divide_dict',
-        'test_floor_divide_float',
-        'test_floor_divide_frozenset',
-        'test_floor_divide_int',
-        'test_floor_divide_list',
-        'test_floor_divide_None',
-        'test_floor_divide_NotImplemented',
-        'test_floor_divide_range',
-        'test_floor_divide_set',
-        'test_floor_divide_slice',
-        'test_floor_divide_str',
-        'test_floor_divide_tuple',
 
         'test_lshift_bool',
         'test_lshift_bytearray',


### PR DESCRIPTION
fixed floor div for bytes to ouput correct error messages as experienced from inside a ipython shell. also removed a variety of not implemented tests that were previousy providign unexpected successes.