### PR TITLE
Split WITH_CLEANUP into WITH_CLEANUP_START/FINISH

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -1761,6 +1761,27 @@ VirtualMachine.prototype.byte_WITH_CLEANUP = function() {
         throw new builtins.BataviaError.$pyclass('Confused WITH_CLEANUP')
     }
     var ret = callables.call_method(mgr, '__exit__', [exc, val, tb])
+    if (constants.BATAVIA_MAGIC === constants.BATAVIA_MAGIC_34) {
+        if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
+                ret.__bool__().valueOf()) {
+            this.push('silenced')
+        }
+    } else {
+        // Assuming Python 3.5
+        this.push(exc)
+        this.push(ret)
+    }
+}
+
+VirtualMachine.prototype.byte_WITH_CLEANUP_FINISH = function() {
+    if (constants.BATAVIA_MAGIC === constants.BATAVIA_MAGIC_34) {
+        throw new builtins.BataviaError.$pyclass(
+            'Unknown opcode WITH_CLEANUP_FINISH in Python 3.4'
+        )
+    }
+    // Assuming Python 3.5
+    var ret = this.pop()
+    var exc = this.pop()
     if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
             ret.__bool__().valueOf()) {
         this.push('silenced')

--- a/batavia/modules/dis.js
+++ b/batavia/modules/dis.js
@@ -124,6 +124,9 @@ def_inplace_op('INPLACE_OR', 79)
 def_op('BREAK_LOOP', 80)
 def_op('WITH_CLEANUP', 81)
 
+// Introduced in Python 3.5
+def_op('WITH_CLEANUP_FINISH', 82)
+
 def_op('RETURN_VALUE', 83)
 def_op('IMPORT_STAR', 84)
 


### PR DESCRIPTION
Opcode 81 - WITH_CLEANUP is replaced in Python 3.5+ by pair of opcodes:
81 - WITH_CLEANUP_START and 82 - WITH_CLEANUP_FINISH