### PR TITLE
Updated python version in tutorial to match guide

### DIFF
--- a/docs/intro/tutorial-0.rst
+++ b/docs/intro/tutorial-0.rst
@@ -4,7 +4,7 @@ Tutorial: Preparing your Environment for Batavia Development
 Getting a working local copy of Batavia requires a few steps: getting a copy of
 the Batavia code, and the ouroboros dependency within a virtual environment.
 
-You'll need to have Python 3.4 available for Batavia to work. Instructions on
+You'll need to have Python 3.5 available for Batavia to work. Instructions on
 how to set this up are `on our Environment setup guide
 <http://pybee.org/contributing/how/first-time/setup/>`_.
 
@@ -21,14 +21,14 @@ how to set this up are `on our Environment setup guide
 
  * For Linux, MacOS::
 
-   $ python3.4 -m venv venv
+   $ python3.5 -m venv venv
    $ . venv/bin/activate
    $ cd batavia
    $ pip install -e .
 
  * For Windows::
 
-   > py -3.4 -m venv venv
+   > py -3.5 -m venv venv
    > venv\Scripts\activate
    > cd batavia
    > pip install -e .

--- a/docs/intro/tutorial-1.rst
+++ b/docs/intro/tutorial-1.rst
@@ -11,7 +11,7 @@ This tutorial assumes you've read and followed the instructions in
 :doc:`the previous tutorial <tutorial-0>`. If you've done this, you should have:
 
 * A ``pybee`` directory with a Batavia checkout,
-* An activated Python 3.4 virtual environment, and
+* An activated Python 3.5 virtual environment, and
 * Batavia installed in that virtual environment
 
 Starting the test server


### PR DESCRIPTION
Current documentation for setting up Batavia environment is for Python 3.4, but link to PyBee environment setup guide for Python 3.5.1 ([https://pybee.org/contributing/how/first-time/setup/](https://pybee.org/contributing/how/first-time/setup/))

This updates documents relating to the Batavia setup to match the environment setup guide to avoid confusion.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
