### PR TITLE
implements list reverse

### DIFF
--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -706,6 +706,13 @@ List.prototype.index = function(value, start, stop) {
     throw new exceptions.ValueError.$pyclass('list.index(x): x not in list')
 }
 
+List.prototype.reverse = function() {
+    if (arguments.length > 0) {
+        throw new exceptions.TypeError.$pyclass('reverse() takes no arguments (' + arguments.length + ' given)')
+    }
+    Array.prototype.reverse.apply(this)
+}
+
 function validateIndexType(index) {
     var types = require('../types')
     if (!types.isinstance(index, types.Int)) {

--- a/tests/datatypes/test_list.py
+++ b/tests/datatypes/test_list.py
@@ -423,6 +423,39 @@ class ListTests(TranspileTestCase):
             print(e)
         """)
 
+    def test_reverse(self):
+        self.assertCodeExecution("""
+        x = []
+        x.reverse()
+        print(x)
+        """)
+
+        self.assertCodeExecution("""
+        x = [1]
+        x.reverse()
+        print(x)
+        """)
+
+        self.assertCodeExecution("""
+        x = [0, 0]
+        x.reverse()
+        print(x)
+        """)
+
+        self.assertCodeExecution("""
+        x = [1, 2]
+        x.reverse()
+        print(x)
+        """)
+
+        self.assertCodeExecution("""
+        x = [1, 2, 3]
+        try:
+            x.reverse(0)
+        except TypeError as e:
+            print(e)
+        """)
+
 
 class UnaryListOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'list'


### PR DESCRIPTION
Implements List instance reverse method
* Adds tests to List datatype for reverse behavior
* Adds implementation to type that raises a TypeError when given any arguments but proxies to Array.prototype.reverse.

## Question:
Should the method return a None type since reverse is an in place procedure?

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct