### PR TITLE
get str() working properly

### DIFF
--- a/batavia/builtins/str.js
+++ b/batavia/builtins/str.js
@@ -7,8 +7,11 @@ function str(args, kwargs) {
     if (kwargs && Object.keys(kwargs).length > 0) {
         throw new exceptions.TypeError.$pyclass("str() doesn't accept keyword arguments")
     }
-    if (!args || args.length !== 1) {
-        throw new exceptions.TypeError.$pyclass('str() takes exactly 1 argument (' + args.length + ' given)')
+
+    if (!args || args.length === 0) {
+        return ''
+    } else if (args.length > 1) {
+        throw new exceptions.TypeError.$pyclass('str() takes at most 1 argument (' + args.length + ' given)')
     }
 
     if (args[0] === null) {

--- a/tests/builtins/test_str.py
+++ b/tests/builtins/test_str.py
@@ -12,6 +12,5 @@ class BuiltinStrFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "str"
 
     not_implemented = [
-        'test_noargs',
         'test_class',
     ]


### PR DESCRIPTION
This change implements pythonic behavior for calling str() with no arguments as part of issue #46 
