### PR TITLE
[WIP] Implement built-in vars()

### DIFF
--- a/batavia/builtins/vars.js
+++ b/batavia/builtins/vars.js
@@ -1,7 +1,26 @@
 var exceptions = require('../core').exceptions
+var locals = require('./locals')
+var hasattr = require('./hasattr')
+var call_method = require('../core').callables.call_method
 
 function vars(args, kwargs) {
-    throw new exceptions.NotImplementedError.$pyclass("Builtin Batavia function 'vars' not implemented")
+    if (arguments.length !== 2) {
+        throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used')
+    }
+    if (kwargs && Object.keys(kwargs).length > 0) {
+        throw new exceptions.TypeError.$pyclass("vars() doesn't accept keyword arguments")
+    }
+    if (args && args.length > 1) {
+        throw new exceptions.TypeError.$pyclass('vars() takes at most one argument (' + args.length + ' given)')
+    }
+    if (!args || args.length === 0) {
+        return locals()
+    }
+    var value = args[0]
+    if (!hasattr([value, '__dict__'])) {
+        throw new exceptions.TypeError.$pyclass('vars() argument must have __dict__ attribute')
+    }
+    return call_method(value, '__dict__')
 }
 vars.__doc__ = 'vars([object]) -> dictionary\n\nWithout arguments, equivalent to locals().\nWith an argument, equivalent to object.__dict__.'
 

--- a/batavia/builtins/vars.js
+++ b/batavia/builtins/vars.js
@@ -1,9 +1,9 @@
 var exceptions = require('../core').exceptions
-var locals = require('./locals')
 var hasattr = require('./hasattr')
 var call_method = require('../core').callables.call_method
 
 function vars(args, kwargs) {
+    var locals = require('../builtins').locals.bind(this)
     if (arguments.length !== 2) {
         throw new exceptions.BataviaError.$pyclass('Batavia calling convention not used')
     }

--- a/tests/builtins/test_vars.py
+++ b/tests/builtins/test_vars.py
@@ -9,22 +9,5 @@ class BuiltinVarsFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "vars"
 
     not_implemented = [
-        'test_noargs',
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
+        "test_class",  # This will fail as long as <type> is missing __dict__
     ]


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Work in progress.

The class test is an expected failure because `type` doesn't implement `__dict__` in Batavia.

Currently the noargs test is failing because Batavia's `locals()` output is not the same as Python's:

```
>>> f = vars
>>> x = "_noargs (should not be use)"
>>> f()
Batavia: {'__builtins__': [object Object], '__name__': '__main__', '__doc__': None, '__package__': None, 'f': function () { [native code] }, 'x': '_noargs (should not be use)'}
Python 3.5: {'x': '_noargs (should not be use)', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0xXXXXXXXX>, '__doc__': None, '__file__': ***EXECUTABLE***, 'f': <built-in function vars>, '__builtins__': <module 'builtins' (built-in)>, '__name__': '__main__', '__cached__': None, '__spec__': None, '__package__': None}
```

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Part of #47.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct