### PR TITLE
Version dependent error messages

### DIFF
--- a/batavia/builtins/bytes.js
+++ b/batavia/builtins/bytes.js
@@ -3,6 +3,7 @@ var Buffer = require('buffer').Buffer
 var exceptions = require('../core').exceptions
 var callables = require('../core').callables
 var type_name = require('../core').type_name
+var constants = require('../core').constants
 var types = require('../types')
 var iter = require('./iter')
 
@@ -26,7 +27,19 @@ function bytes(args, kwargs) {
     } else if (args.length === 1) {
         var arg = args[0]
         if (arg === null) {
-            throw new exceptions.TypeError.$pyclass("'NoneType' object is not iterable")
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'NoneType' object is not iterable"
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "cannot convert 'NoneType' object to bytes"
+                    )
+            }
         } else if (types.isinstance(arg, types.Int)) {
             // bytes(int) -> bytes array of size given by the parameter initialized with null bytes
             // Batavia ints are BigNumbers, so we need to unpack the value from the BigNumber Array.
@@ -98,9 +111,19 @@ function bytes(args, kwargs) {
             return new types.Bytes(Buffer.from(buffer_args))
         } else {
             // the argument is not one of the special cases, and not an iterable, so...
-            throw new exceptions.TypeError.$pyclass(
-            //    "'" + type_name(val) + "' object is not iterable");
-            "'" + type_name(arg) + "' object is not iterable")
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'" + type_name(arg) + "' object is not iterable"
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "cannot convert '" + type_name(arg) + "' object to bytes"
+                    )
+            }
         }
     } else if (args.length >= 2 && args.length <= 3) {
         //    bytes(string, encoding[, errors]) -> bytes

--- a/batavia/builtins/chr.js
+++ b/batavia/builtins/chr.js
@@ -17,6 +17,7 @@ function chr(args, kwargs) {
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
             case constants.BATAVIA_MAGIC_353:
+            case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass('chr() takes exactly one argument (' + args.length + ' given)')
 
             default:

--- a/batavia/core/exceptions.js
+++ b/batavia/core/exceptions.js
@@ -441,4 +441,13 @@ ZeroDivisionError.prototype.__class__.$pyclass = ZeroDivisionError
 
 exceptions.ZeroDivisionError = ZeroDivisionError.prototype.__class__
 
+var JSONDecodeError = function(msg) {
+    Exception.call(this, 'JSONDecodeError', msg)
+}
+JSONDecodeError.prototype = Object.create(Exception.prototype)
+JSONDecodeError.prototype.__class__ = new Type('JSONDecodeError', [Exception.prototype.__class__])
+JSONDecodeError.prototype.__class__.$pyclass = JSONDecodeError
+
+exceptions.JSONDecodeError = JSONDecodeError.prototype.__class__
+
 module.exports = exceptions

--- a/batavia/core/types/NoneType.js
+++ b/batavia/core/types/NoneType.js
@@ -49,7 +49,7 @@ NoneType.prototype.__setattr__ = function(attr, value) {
  **************************************************/
 
 NoneType.prototype.__lt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -66,7 +66,7 @@ NoneType.prototype.__lt__ = function(other) {
 }
 
 NoneType.prototype.__le__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -91,7 +91,7 @@ NoneType.prototype.__ne__ = function(other) {
 }
 
 NoneType.prototype.__gt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -108,7 +108,7 @@ NoneType.prototype.__gt__ = function(other) {
 }
 
 NoneType.prototype.__ge__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:

--- a/batavia/core/types/NoneType.js
+++ b/batavia/core/types/NoneType.js
@@ -4,6 +4,7 @@
 var PyObject = require('./Object')
 var basic_types = require('./Type')
 var exceptions = require('../exceptions')
+var constants = require('../constants')
 
 function NoneType() {
     PyObject.call(this)
@@ -48,11 +49,37 @@ NoneType.prototype.__setattr__ = function(attr, value) {
  **************************************************/
 
 NoneType.prototype.__lt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NoneType() < ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NoneType() < ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'NoneType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NoneType.prototype.__le__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NoneType() <= ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NoneType() <= ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'NoneType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NoneType.prototype.__eq__ = function(other) {
@@ -64,11 +91,37 @@ NoneType.prototype.__ne__ = function(other) {
 }
 
 NoneType.prototype.__gt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NoneType() > ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NoneType() > ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>' not supported between instances of 'NoneType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NoneType.prototype.__ge__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NoneType() >= ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NoneType() >= ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>=' not supported between instances of 'NoneType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NoneType.prototype.__contains__ = function(other) {

--- a/batavia/core/types/NotImplementedType.js
+++ b/batavia/core/types/NotImplementedType.js
@@ -43,7 +43,7 @@ NotImplementedType.prototype.__str__ = function() {
  **************************************************/
 
 NotImplementedType.prototype.__lt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -60,7 +60,7 @@ NotImplementedType.prototype.__lt__ = function(other) {
 }
 
 NotImplementedType.prototype.__le__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -85,7 +85,7 @@ NotImplementedType.prototype.__ne__ = function(other) {
 }
 
 NotImplementedType.prototype.__gt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -102,7 +102,7 @@ NotImplementedType.prototype.__gt__ = function(other) {
 }
 
 NotImplementedType.prototype.__ge__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:

--- a/batavia/core/types/NotImplementedType.js
+++ b/batavia/core/types/NotImplementedType.js
@@ -4,6 +4,7 @@
 var PyObject = require('./Object')
 var basic_types = require('./Type')
 var exceptions = require('../exceptions')
+var constants = require('../constants')
 
 function NotImplementedType() {
     PyObject.call(this)
@@ -42,11 +43,37 @@ NotImplementedType.prototype.__str__ = function() {
  **************************************************/
 
 NotImplementedType.prototype.__lt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NotImplementedType() < ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NotImplementedType() < ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'NotImplementedType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NotImplementedType.prototype.__le__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NotImplementedType() <= ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NotImplementedType() <= ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'NotImplementedType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NotImplementedType.prototype.__eq__ = function(other) {
@@ -58,11 +85,37 @@ NotImplementedType.prototype.__ne__ = function(other) {
 }
 
 NotImplementedType.prototype.__gt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NotImplementedType() > ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NotImplementedType() > ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>' not supported between instances of 'NotImplementedType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NotImplementedType.prototype.__ge__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: NotImplementedType() >= ' + basic_types.type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: NotImplementedType() >= ' + basic_types.type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>=' not supported between instances of 'NotImplementedType' and '" +
+                basic_types.type_name(other) + "'"
+            )
+    }
 }
 
 NotImplementedType.prototype.__contains__ = function(other) {

--- a/batavia/modules/json/decoder.js
+++ b/batavia/modules/json/decoder.js
@@ -3,6 +3,7 @@ var core = require('../../core')
 var PyObject = core.Object
 var exceptions = core.exceptions
 var callables = core.callables
+var constants = core.constants
 var validateParams = require('./utils').validateParams
 
 function JSONDecoder() {
@@ -63,7 +64,11 @@ JSONDecoder.prototype.decode = function(s) {
     try {
         ret = JSON.parse(s, reviver)
     } catch (e) {
-        throw new exceptions.ValueError.$pyclass(e.message)
+        if (constants.BATAVIA_MAGIC === constants.BATAVIA_MAGIC_34) {
+            throw new exceptions.ValueError.$pyclass(e.message)
+        } else {
+            throw new exceptions.JSONDecodeError.$pyclass(e.message)
+        }
     }
     return ret
 }
@@ -94,7 +99,6 @@ var loads = function(args, kwargs) {
     delete params['encoding']
     params['strict'] = true
 
-    // TODO(abonie): possible bug here? see test_cls in tests
     var dec = callables.call_function(cls, [], params)
     return callables.call_method(dec, 'decode', [s])
 }
@@ -132,5 +136,6 @@ load.$pyargs = true
 module.exports = {
     'loads': loads,
     'load': load,
+    'JSONDecodeError': exceptions.JSONDecodeError,
     'JSONDecoder': _JSONDecoder
 }

--- a/batavia/modules/json/encoder.js
+++ b/batavia/modules/json/encoder.js
@@ -2,6 +2,8 @@ var PyObject = require('../../core').Object
 var create_pyclass = require('../../core').create_pyclass
 var callables = require('../../core').callables
 var exceptions = require('../../core').exceptions
+var constants = require('../../core').constants
+var type_name = require('../../core').type_name
 var types = require('../../types')
 var builtins = require('../../builtins')
 var validateParams = require('./utils').validateParams
@@ -176,9 +178,19 @@ var make_encode = function(
             } else if (default_) {
                 ret = encode(callables.call_function(default_, [obj]), indent_level)
             } else {
-                throw new exceptions.TypeError.$pyclass(
-                    obj.toString() + ' is not JSON serializable'
-                )
+                switch (constants.BATAVIA_MAGIC) {
+                    case constants.BATAVIA_MAGIC_34:
+                    case constants.BATAVIA_MAGIC_35a0:
+                    case constants.BATAVIA_MAGIC_35:
+                    case constants.BATAVIA_MAGIC_353:
+                        throw new exceptions.TypeError.$pyclass(
+                            obj.toString() + ' is not JSON serializable'
+                        )
+                    case constants.BATAVIA_MAGIC_36:
+                        throw new exceptions.TypeError.$pyclass(
+                            "Object of type '" + type_name(obj) + "' is not JSON serializable"
+                        )
+                }
             }
 
             if (seen !== undefined) {

--- a/batavia/types/Bool.js
+++ b/batavia/types/Bool.js
@@ -1,5 +1,6 @@
 var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var utils = require('./utils')
 /*************************************************************************
@@ -99,7 +100,20 @@ Bool.prototype.__ge__ = function(other) {
         }
         return new Bool(this_bool >= other_bool)
     } else if (types.isbataviainstance(other)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bool() >= ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bool() >= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'bool' and '" +
+                    type_name(other) + "'"
+                )
+        }
     } else {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for >=: 'bool' and '" + type_name(other) + "'")
     }
@@ -131,7 +145,20 @@ Bool.prototype.__gt__ = function(other) {
         }
         return new Bool(this_bool > other_bool)
     } else if (types.isbataviainstance(other)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bool() > ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bool() > ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'bool' and '" +
+                    type_name(other) + "'"
+                )
+        }
     } else {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for >: 'bool' and '" + type_name(other) + "'")
     }
@@ -163,7 +190,20 @@ Bool.prototype.__le__ = function(other) {
         }
         return new Bool(this_bool <= other_bool)
     } else if (types.isbataviainstance(other)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bool() <= ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bool() <= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'bool' and '" +
+                    type_name(other) + "'"
+                )
+        }
     } else {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for <=: 'bool' and '" + type_name(other) + "'")
     }
@@ -195,7 +235,20 @@ Bool.prototype.__lt__ = function(other) {
         }
         return new Bool(this_bool < other_bool)
     } else if (types.isbataviainstance(other)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bool() < ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bool() < ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'bool' and '" +
+                    type_name(other) + "'"
+                )
+        }
     } else {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for <: 'bool' and '" + type_name(other) + "'")
     }

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -89,7 +89,20 @@ Bytes.prototype.__lt__ = function(other) {
     if (types.isinstance(other, Bytes)) {
         return this.val < other.val
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bytes() < ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bytes() < ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'bytes' and '"
+                    + type_name(other) + "'"
+                )
+        }
     }
 }
 
@@ -99,7 +112,20 @@ Bytes.prototype.__le__ = function(other) {
     if (types.isinstance(other, Bytes)) {
         return this.val <= other.val
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bytes() <= ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bytes() <= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'bytes' and '"
+                    + type_name(other) + "'"
+                )
+        }
     }
 }
 
@@ -127,7 +153,20 @@ Bytes.prototype.__gt__ = function(other) {
     if (types.isinstance(other, Bytes)) {
         return this.val > other.val
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bytes() > ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bytes() > ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'bytes' and '"
+                    + type_name(other) + "'"
+                )
+        }
     }
 }
 
@@ -137,7 +176,20 @@ Bytes.prototype.__ge__ = function(other) {
     if (types.isinstance(other, Bytes)) {
         return this.val >= other.val
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: bytes() >= ' + type_name(other) + '()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: bytes() >= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'bytes' and '"
+                    + type_name(other) + "'"
+                )
+        }
     }
 }
 

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -99,8 +99,8 @@ Bytes.prototype.__lt__ = function(other) {
                 )
             case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass(
-                    "'<' not supported between instances of 'bytes' and '"
-                    + type_name(other) + "'"
+                    "'<' not supported between instances of 'bytes' and '" +
+                    type_name(other) + "'"
                 )
         }
     }
@@ -122,8 +122,8 @@ Bytes.prototype.__le__ = function(other) {
                 )
             case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass(
-                    "'<=' not supported between instances of 'bytes' and '"
-                    + type_name(other) + "'"
+                    "'<=' not supported between instances of 'bytes' and '" +
+                    type_name(other) + "'"
                 )
         }
     }
@@ -163,8 +163,8 @@ Bytes.prototype.__gt__ = function(other) {
                 )
             case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass(
-                    "'>' not supported between instances of 'bytes' and '"
-                    + type_name(other) + "'"
+                    "'>' not supported between instances of 'bytes' and '" +
+                    type_name(other) + "'"
                 )
         }
     }
@@ -186,8 +186,8 @@ Bytes.prototype.__ge__ = function(other) {
                 )
             case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass(
-                    "'>=' not supported between instances of 'bytes' and '"
-                    + type_name(other) + "'"
+                    "'>=' not supported between instances of 'bytes' and '" +
+                    type_name(other) + "'"
                 )
         }
     }
@@ -332,7 +332,7 @@ Bytes.prototype.__add__ = function(other) {
         types.Str,
         types.Tuple ])) {
         // does not concat with all these
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -342,10 +342,9 @@ Bytes.prototype.__add__ = function(other) {
                 )
             case constants.BATAVIA_MAGIC_36:
                 throw new exceptions.TypeError.$pyclass(
-                    "can't concat " + type_name(other) + " to bytes"
+                    "can't concat " + type_name(other) + ' to bytes'
                 )
         }
-
     } else {
         throw new exceptions.NotImplementedError.$pyclass('Bytes.__add__ has not been implemented')
     }

--- a/batavia/types/Bytes.js
+++ b/batavia/types/Bytes.js
@@ -332,7 +332,20 @@ Bytes.prototype.__add__ = function(other) {
         types.Str,
         types.Tuple ])) {
         // does not concat with all these
-        throw new exceptions.TypeError.$pyclass("can't concat bytes to " + type_name(other))
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    "can't concat bytes to " + type_name(other)
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "can't concat " + type_name(other) + " to bytes"
+                )
+        }
+
     } else {
         throw new exceptions.NotImplementedError.$pyclass('Bytes.__add__ has not been implemented')
     }

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -1,7 +1,6 @@
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
 var constants = require('../core').constants
-var constants = require('../core').constants
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 
@@ -151,7 +150,7 @@ Complex.prototype.__str__ = function() {
  **************************************************/
 
 Complex.prototype.__lt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -167,7 +166,7 @@ Complex.prototype.__lt__ = function(other) {
 }
 
 Complex.prototype.__le__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -209,7 +208,7 @@ Complex.prototype.__ne__ = function(other) {
 }
 
 Complex.prototype.__gt__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -225,7 +224,7 @@ Complex.prototype.__gt__ = function(other) {
 }
 
 Complex.prototype.__ge__ = function(other) {
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -1,5 +1,6 @@
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 
@@ -60,13 +61,37 @@ function Complex(re, im) {
             this.imag = -this.imag
         }
     } else if (!types.isinstance(re, [types.Float, types.Int, types.Bool, types.Complex])) {
-        throw new exceptions.TypeError.$pyclass(
-            "complex() argument must be a string, a bytes-like object or a number, not '" + type_name(re) + "'"
-        )
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+                throw new exceptions.TypeError.$pyclass(
+                    "complex() argument must be a string, a bytes-like object or a number, not '" +
+                    type_name(re) + "'"
+                )
+            case constants.BATAVIA_MAGIC_353:
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "complex() first argument must be a string, a bytes-like object or a number, not '" +
+                    type_name(re) + "'"
+                )
+        }
     } else if (!types.isinstance(im, [types.Float, types.Int, types.Bool, types.Complex])) {
-        throw new exceptions.TypeError.$pyclass(
-            "complex() argument must be a string, a bytes-like object or a number, not '" + type_name(im) + "'"
-        )
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+                throw new exceptions.TypeError.$pyclass(
+                    "complex() argument must be a string, a bytes-like object or a number, not '" +
+                    type_name(im) + "'"
+                )
+            case constants.BATAVIA_MAGIC_353:
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "complex() first argument must be a string, a bytes-like object or a number, not '" +
+                    type_name(im) + "'"
+                )
+        }
     } else if (typeof re === 'number' && typeof im === 'number') {
         this.real = re
         this.imag = im

--- a/batavia/types/Complex.js
+++ b/batavia/types/Complex.js
@@ -1,6 +1,7 @@
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
 var constants = require('../core').constants
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 
@@ -150,11 +151,35 @@ Complex.prototype.__str__ = function() {
  **************************************************/
 
 Complex.prototype.__lt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: complex() < ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: complex() < ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'complex' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Complex.prototype.__le__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: complex() <= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: complex() <= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'complex' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Complex.prototype.__eq__ = function(other) {
@@ -184,11 +209,35 @@ Complex.prototype.__ne__ = function(other) {
 }
 
 Complex.prototype.__gt__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: complex() > ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: complex() > ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>' not supported between instances of 'complex' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Complex.prototype.__ge__ = function(other) {
-    throw new exceptions.TypeError.$pyclass('unorderable types: complex() >= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: complex() >= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>=' not supported between instances of 'complex' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 /**************************************************

--- a/batavia/types/Dict.js
+++ b/batavia/types/Dict.js
@@ -1,5 +1,6 @@
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var callables = require('../core').callables
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
@@ -168,24 +169,74 @@ Dict.prototype.__lt__ = function(other) {
     var types = require('../types')
     if (other !== None) {
         if (types.isbataviainstance(other)) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() < ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'dict' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() < other.valueOf()
         }
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: dict() < NoneType()')
+    switch (constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: dict() < NoneType()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'dict' and 'NoneType'"
+            )
+    }
 }
 
 Dict.prototype.__le__ = function(other) {
     var types = require('../types')
     if (other !== None) {
         if (types.isbataviainstance(other)) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() <= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'dict' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() <= other.valueOf()
         }
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: dict() <= NoneType()')
+    switch (constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: dict() <= NoneType()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'dict' and 'NoneType'"
+            )
+    }
 }
 
 Dict.prototype.__eq__ = function(other) {
@@ -224,12 +275,37 @@ Dict.prototype.__gt__ = function(other) {
     var types = require('../types')
     if (other !== None) {
         if (types.isbataviainstance(other)) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() > ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'dict' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() > other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: dict() > NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: dict() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'dict' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -237,12 +313,37 @@ Dict.prototype.__ge__ = function(other) {
     var types = require('../types')
     if (other !== None) {
         if (types.isbataviainstance(other)) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() >= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'dict' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() >= other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: dict() >= NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: dict() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'dict' and 'NoneType'"
+                )
+        }
     }
 }
 

--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -1,5 +1,6 @@
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
@@ -96,12 +97,37 @@ Float.prototype.__lt__ = function(other) {
             types.Range, types.Set, types.Slice,
             types.Bytes, types.Bytearray
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: float() < ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: float() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'float' and '"
+                        + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() < other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: float() < NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: float() < NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'float' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -114,12 +140,37 @@ Float.prototype.__le__ = function(other) {
             types.NoneType, types.Str, types.NotImplementedType,
             types.Range, types.Set, types.Slice
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: float() <= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: float() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'float' and '"
+                        + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() <= other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: float() <= NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: float() <= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'float' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -157,12 +208,37 @@ Float.prototype.__gt__ = function(other) {
             types.NoneType, types.Str, types.NotImplementedType,
             types.Range, types.Set, types.Slice
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: float() > ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: float() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'float' and '"
+                        + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() > other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: float() > NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: float() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'float' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -176,11 +252,37 @@ Float.prototype.__ge__ = function(other) {
             types.Range, types.Set, types.Slice,
             types.Bytes, types.Bytearray
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: float() >= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: float() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'float' and '"
+                        + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() >= other.valueOf()
         }
     } else {
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: float() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'float' and 'NoneType'"
+                )
+        }
         throw new exceptions.TypeError.$pyclass('unorderable types: float() >= NoneType()')
     }
 }

--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -107,8 +107,8 @@ Float.prototype.__lt__ = function(other) {
                     )
                 case constants.BATAVIA_MAGIC_36:
                     throw new exceptions.TypeError.$pyclass(
-                        "'<' not supported between instances of 'float' and '"
-                        + type_name(other) + "'"
+                        "'<' not supported between instances of 'float' and '" +
+                        type_name(other) + "'"
                     )
             }
         } else {
@@ -150,8 +150,8 @@ Float.prototype.__le__ = function(other) {
                     )
                 case constants.BATAVIA_MAGIC_36:
                     throw new exceptions.TypeError.$pyclass(
-                        "'<=' not supported between instances of 'float' and '"
-                        + type_name(other) + "'"
+                        "'<=' not supported between instances of 'float' and '" +
+                        type_name(other) + "'"
                     )
             }
         } else {
@@ -218,8 +218,8 @@ Float.prototype.__gt__ = function(other) {
                     )
                 case constants.BATAVIA_MAGIC_36:
                     throw new exceptions.TypeError.$pyclass(
-                        "'>' not supported between instances of 'float' and '"
-                        + type_name(other) + "'"
+                        "'>' not supported between instances of 'float' and '" +
+                        type_name(other) + "'"
                     )
             }
         } else {
@@ -262,8 +262,8 @@ Float.prototype.__ge__ = function(other) {
                     )
                 case constants.BATAVIA_MAGIC_36:
                     throw new exceptions.TypeError.$pyclass(
-                        "'>=' not supported between instances of 'float' and '"
-                        + type_name(other) + "'"
+                        "'>=' not supported between instances of 'float' and '" +
+                        type_name(other) + "'"
                     )
             }
         } else {

--- a/batavia/types/FrozenSet.js
+++ b/batavia/types/FrozenSet.js
@@ -1,6 +1,7 @@
 var PyObject = require('../core').Object
 var create_pyclass = require('../core').create_pyclass
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var callables = require('../core').callables
 var type_name = require('../core').type_name
 var SetIterator = require('./SetIterator')
@@ -70,7 +71,20 @@ FrozenSet.prototype.__lt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length < other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: frozenset() < ' + type_name(other) + '()')
+
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: frozenset() < ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'frozenset' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 FrozenSet.prototype.__le__ = function(other) {
@@ -79,7 +93,19 @@ FrozenSet.prototype.__le__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length <= other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: frozenset() <= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: frozenset() <= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'frozenset' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 FrozenSet.prototype.__eq__ = function(other) {
@@ -111,7 +137,19 @@ FrozenSet.prototype.__gt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length > other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: frozenset() > ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: frozenset() > ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>' not supported between instances of 'frozenset' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 FrozenSet.prototype.__ge__ = function(other) {
@@ -120,7 +158,19 @@ FrozenSet.prototype.__ge__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length >= other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: frozenset() >= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: frozenset() >= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>=' not supported between instances of 'frozenset' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 FrozenSet.prototype.__contains__ = function(other) {

--- a/batavia/types/FrozenSet.js
+++ b/batavia/types/FrozenSet.js
@@ -72,7 +72,7 @@ FrozenSet.prototype.__lt__ = function(other) {
         return new types.Bool(this.data.keys().length < other.data.keys().length)
     }
 
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -93,7 +93,7 @@ FrozenSet.prototype.__le__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length <= other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -137,7 +137,7 @@ FrozenSet.prototype.__gt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length > other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -158,7 +158,7 @@ FrozenSet.prototype.__ge__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length >= other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -2,6 +2,7 @@ var BigNumber = require('bignumber.js')
 
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 var None = require('../core').None
@@ -105,10 +106,35 @@ Int.prototype.__lt__ = function(other) {
         } else if (types.isinstance(other, types.Float)) {
             return this.val.lt(other.valueOf())
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: int() < ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: int() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'int' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: int() < NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: int() < NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'int' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -127,10 +153,35 @@ Int.prototype.__le__ = function(other) {
         } else if (types.isinstance(other, types.Float)) {
             return this.val.lte(other.valueOf())
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: int() <= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: int() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'int' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: int() <= NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: int() <= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'int' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -169,10 +220,35 @@ Int.prototype.__gt__ = function(other) {
         } else if (types.isinstance(other, types.Float)) {
             return this.val.gt(other.valueOf())
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: int() > ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: int() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'int' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: int() > NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: int() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'int' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -191,10 +267,35 @@ Int.prototype.__ge__ = function(other) {
         } else if (types.isinstance(other, types.Float)) {
             return this.val.gte(other.valueOf())
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: int() >= ' + type_name(other) + '()')
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: int() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'int' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: int() >= NoneType()')
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: int() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'int' and 'NoneType'"
+                )
+        }
     }
 }
 

--- a/batavia/types/JSDict.js
+++ b/batavia/types/JSDict.js
@@ -66,7 +66,7 @@ JSDict.prototype.__lt__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -83,7 +83,7 @@ JSDict.prototype.__lt__ = function(other) {
             return this.valueOf() < other.valueOf()
         }
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -107,7 +107,7 @@ JSDict.prototype.__le__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -124,7 +124,7 @@ JSDict.prototype.__le__ = function(other) {
             return this.valueOf() <= other.valueOf()
         }
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -157,7 +157,7 @@ JSDict.prototype.__gt__ = function(other) {
             types.NoneType, types.Set, types.Str,
             types.Tuple
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -174,7 +174,7 @@ JSDict.prototype.__gt__ = function(other) {
             return this.valueOf() > other.valueOf()
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -199,7 +199,7 @@ JSDict.prototype.__ge__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -216,7 +216,7 @@ JSDict.prototype.__ge__ = function(other) {
             return this.valueOf() >= other.valueOf()
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/JSDict.js
+++ b/batavia/types/JSDict.js
@@ -1,4 +1,5 @@
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var None = require('../core').None
 
@@ -65,12 +66,36 @@ JSDict.prototype.__lt__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() < ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'dict' and '" + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() < other.valueOf()
         }
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: dict() < NoneType()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: dict() < NoneType()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'dict' and 'NoneType'"
+            )
+    }
 }
 
 JSDict.prototype.__le__ = function(other) {
@@ -82,12 +107,36 @@ JSDict.prototype.__le__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() <= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'dict' and '" + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() <= other.valueOf()
         }
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: dict() <= NoneType()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: dict() <= NoneType()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'dict' and 'NoneType'"
+            )
+    }
 }
 
 JSDict.prototype.__eq__ = function(other) {
@@ -108,12 +157,36 @@ JSDict.prototype.__gt__ = function(other) {
             types.NoneType, types.Set, types.Str,
             types.Tuple
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() > ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'dict' and '" + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() > other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: dict() > NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: dict() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'dict' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -126,12 +199,36 @@ JSDict.prototype.__ge__ = function(other) {
             types.Int, types.JSDict, types.List,
             types.NoneType, types.Str, types.Tuple
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: dict() >= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: dict() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'dict' and '" + type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() >= other.valueOf()
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: dict() >= NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: dict() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'dict' and 'NoneType'"
+                )
+        }
     }
 }
 

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -84,7 +84,7 @@ List.prototype.__lt__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -119,7 +119,7 @@ List.prototype.__lt__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length < other.length
         } else {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -135,7 +135,7 @@ List.prototype.__lt__ = function(other) {
             }
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -155,7 +155,7 @@ List.prototype.__le__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -190,7 +190,7 @@ List.prototype.__le__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length <= other.length
         } else {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -206,7 +206,7 @@ List.prototype.__le__ = function(other) {
             }
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -249,7 +249,7 @@ List.prototype.__gt__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -284,7 +284,7 @@ List.prototype.__gt__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length > other.length
         } else {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -300,7 +300,7 @@ List.prototype.__gt__ = function(other) {
             }
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -320,7 +320,7 @@ List.prototype.__ge__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -355,7 +355,7 @@ List.prototype.__ge__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length >= other.length
         } else {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -371,7 +371,7 @@ List.prototype.__ge__ = function(other) {
             }
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -84,7 +84,20 @@ List.prototype.__lt__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() < ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() < ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'list' and '" +
+                    type_name(other) + "'"
+                )
+        }
     }
 
     if (other !== None) {
@@ -106,10 +119,35 @@ List.prototype.__lt__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length < other.length
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: list() < ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: list() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'list' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() < NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() < NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'list' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -117,7 +155,20 @@ List.prototype.__le__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() <= ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() <= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'list' and '" +
+                    type_name(other) + "'"
+                )
+        }
     }
 
     if (other !== None) {
@@ -139,10 +190,35 @@ List.prototype.__le__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length <= other.length
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: list() <= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: list() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'list' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() <= NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() <= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'list' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -173,7 +249,20 @@ List.prototype.__gt__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() > ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() > ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'list' and '" +
+                    type_name(other) + "'"
+                )
+        }
     }
 
     if (other !== None) {
@@ -195,10 +284,35 @@ List.prototype.__gt__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length > other.length
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: list() > ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: list() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'list' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() > NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'list' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -206,7 +320,20 @@ List.prototype.__ge__ = function(other) {
     var types = require('../types')
 
     if (types.isinstance(other, [types.Bytes, types.Bytearray])) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() >= ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() >= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'list' and '" +
+                    type_name(other) + "'"
+                )
+        }
     }
 
     if (other !== None) {
@@ -228,10 +355,35 @@ List.prototype.__ge__ = function(other) {
             // got through loop and all values were equal. Determine by comparing length
             return this.length >= other.length
         } else {
-            throw new exceptions.TypeError.$pyclass('unorderable types: list() >= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: list() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'list' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: list() >= NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: list() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'list' and 'NoneType'"
+                )
+        }
     }
 }
 

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -70,7 +70,7 @@ Set.prototype.__lt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length < other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -91,7 +91,7 @@ Set.prototype.__le__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length <= other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -135,7 +135,7 @@ Set.prototype.__gt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length > other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:
@@ -156,7 +156,7 @@ Set.prototype.__ge__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length >= other.data.keys().length)
     }
-    switch(constants.BATAVIA_MAGIC) {
+    switch (constants.BATAVIA_MAGIC) {
         case constants.BATAVIA_MAGIC_34:
         case constants.BATAVIA_MAGIC_35a0:
         case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-extend-native */
 var PyObject = require('../core').Object
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var callables = require('../core').callables
 var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
@@ -69,7 +70,19 @@ Set.prototype.__lt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length < other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: set() < ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: set() < ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<' not supported between instances of 'set' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Set.prototype.__le__ = function(other) {
@@ -78,7 +91,19 @@ Set.prototype.__le__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length <= other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: set() <= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: set() <= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'<=' not supported between instances of 'set' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Set.prototype.__eq__ = function(other) {
@@ -110,7 +135,19 @@ Set.prototype.__gt__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length > other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: set() > ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: set() > ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>' not supported between instances of 'set' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Set.prototype.__ge__ = function(other) {
@@ -119,7 +156,19 @@ Set.prototype.__ge__ = function(other) {
     if (types.isinstance(other, [types.Set, types.FrozenSet])) {
         return new types.Bool(this.data.keys().length >= other.data.keys().length)
     }
-    throw new exceptions.TypeError.$pyclass('unorderable types: set() >= ' + type_name(other) + '()')
+    switch(constants.BATAVIA_MAGIC) {
+        case constants.BATAVIA_MAGIC_34:
+        case constants.BATAVIA_MAGIC_35a0:
+        case constants.BATAVIA_MAGIC_35:
+        case constants.BATAVIA_MAGIC_353:
+            throw new exceptions.TypeError.$pyclass(
+                'unorderable types: set() >= ' + type_name(other) + '()'
+            )
+        case constants.BATAVIA_MAGIC_36:
+            throw new exceptions.TypeError.$pyclass(
+                "'>=' not supported between instances of 'set' and '" + type_name(other) + "'"
+            )
+    }
 }
 
 Set.prototype.__contains__ = function(other) {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -388,7 +388,17 @@ Str.prototype.__add__ = function(other) {
     if (types.isinstance(other, Str)) {
         return this.valueOf() + other.valueOf()
     } else {
-        throw new exceptions.TypeError.$pyclass("Can't convert '" + type_name(other) + "' object to str implicitly")
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    "Can't convert '" + type_name(other) + "' object to str implicitly"
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass('must be str, not ' + type_name(other))
+        }
     }
 }
 
@@ -550,7 +560,17 @@ Str.prototype.__iadd__ = function(other) {
     if (types.isinstance(other, Str)) {
         return this.valueOf() + other.valueOf()
     } else {
-        throw new exceptions.TypeError.$pyclass("Can't convert '" + type_name(other) + "' object to str implicitly")
+        switch (constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    "Can't convert '" + type_name(other) + "' object to str implicitly"
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass('must be str, not ' + type_name(other))
+        }
     }
 }
 

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -90,7 +90,7 @@ Str.prototype.__lt__ = function(other) {
             types.Range, types.Set, types.Slice,
             types.FrozenSet
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -108,7 +108,7 @@ Str.prototype.__lt__ = function(other) {
             return this.valueOf() < other
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -135,7 +135,7 @@ Str.prototype.__le__ = function(other) {
             types.Type, types.Complex, types.NotImplementedType,
             types.Range, types.Slice, types.FrozenSet
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -153,7 +153,7 @@ Str.prototype.__le__ = function(other) {
             return this.valueOf() <= other
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -216,7 +216,7 @@ Str.prototype.__gt__ = function(other) {
             types.NotImplementedType, types.Range,
             types.Slice, types.FrozenSet
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -234,7 +234,7 @@ Str.prototype.__gt__ = function(other) {
             return this.valueOf() > other
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -262,7 +262,7 @@ Str.prototype.__ge__ = function(other) {
             types.Range, types.Slice, types.FrozenSet
 
         ])) {
-            switch(constants.BATAVIA_MAGIC) {
+            switch (constants.BATAVIA_MAGIC) {
                 case constants.BATAVIA_MAGIC_34:
                 case constants.BATAVIA_MAGIC_35a0:
                 case constants.BATAVIA_MAGIC_35:
@@ -280,7 +280,7 @@ Str.prototype.__ge__ = function(other) {
             return this.valueOf() >= other
         }
     } else {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -90,12 +90,37 @@ Str.prototype.__lt__ = function(other) {
             types.Range, types.Set, types.Slice,
             types.FrozenSet
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: str() < ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: str() < ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<' not supported between instances of 'str' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() < other
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: str() < NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: str() < NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'str' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -110,12 +135,37 @@ Str.prototype.__le__ = function(other) {
             types.Type, types.Complex, types.NotImplementedType,
             types.Range, types.Slice, types.FrozenSet
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: str() <= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: str() <= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'<=' not supported between instances of 'str' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() <= other
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: str() <= NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: str() <= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'str' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -166,12 +216,37 @@ Str.prototype.__gt__ = function(other) {
             types.NotImplementedType, types.Range,
             types.Slice, types.FrozenSet
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: str() > ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: str() > ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>' not supported between instances of 'str' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() > other
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: str() > NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: str() > NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'str' and 'NoneType'"
+                )
+        }
     }
 }
 
@@ -187,12 +262,37 @@ Str.prototype.__ge__ = function(other) {
             types.Range, types.Slice, types.FrozenSet
 
         ])) {
-            throw new exceptions.TypeError.$pyclass('unorderable types: str() >= ' + type_name(other) + '()')
+            switch(constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.TypeError.$pyclass(
+                        'unorderable types: str() >= ' + type_name(other) + '()'
+                    )
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.TypeError.$pyclass(
+                        "'>=' not supported between instances of 'str' and '" +
+                        type_name(other) + "'"
+                    )
+            }
         } else {
             return this.valueOf() >= other
         }
     } else {
-        throw new exceptions.TypeError.$pyclass('unorderable types: str() >= NoneType()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: str() >= NoneType()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'str' and 'NoneType'"
+                )
+        }
     }
 }
 

--- a/batavia/types/StrUtils.js
+++ b/batavia/types/StrUtils.js
@@ -1,4 +1,5 @@
 var exceptions = require('../core').exceptions
+var constants = require('../core').constants
 var type_name = require('../core').type_name
 var BigNumber = require('bignumber.js').BigNumber
 
@@ -1182,7 +1183,15 @@ function _new_subsitute(str, args, kwargs) {
             // sign
             // alternate form
         if (this.grouping === ',') {
-            throw new exceptions.ValueError.$pyclass("Cannot specify ',' with 's'.")
+            switch (constants.BATAVIA_MAGIC) {
+                case constants.BATAVIA_MAGIC_34:
+                case constants.BATAVIA_MAGIC_35a0:
+                case constants.BATAVIA_MAGIC_35:
+                case constants.BATAVIA_MAGIC_353:
+                    throw new exceptions.ValueError.$pyclass("Cannot specify ',' with 's'.")
+                case constants.BATAVIA_MAGIC_36:
+                    throw new exceptions.ValueError.$pyclass("Cannot specify ',' or '_' with 's'.")
+            }
         }
 
         if (this.sign) {

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -87,7 +87,7 @@ Tuple.prototype.__lt__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -123,7 +123,7 @@ Tuple.prototype.__le__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -177,7 +177,7 @@ Tuple.prototype.__gt__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:
@@ -214,7 +214,7 @@ Tuple.prototype.__ge__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        switch(constants.BATAVIA_MAGIC) {
+        switch (constants.BATAVIA_MAGIC) {
             case constants.BATAVIA_MAGIC_34:
             case constants.BATAVIA_MAGIC_35a0:
             case constants.BATAVIA_MAGIC_35:

--- a/batavia/types/Tuple.js
+++ b/batavia/types/Tuple.js
@@ -87,7 +87,19 @@ Tuple.prototype.__lt__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: tuple() < ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: tuple() < ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<' not supported between instances of 'tuple' and '" + type_name(other) + "'"
+                )
+        }
     }
     if (this.length === 0 && other.length > 0) {
         return new types.Bool(true)
@@ -111,7 +123,19 @@ Tuple.prototype.__le__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: tuple() <= ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: tuple() <= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'<=' not supported between instances of 'tuple' and '" + type_name(other) + "'"
+                )
+        }
     }
     for (var i = 0; i < this.length; i++) {
         if (i >= other.length) {
@@ -153,7 +177,19 @@ Tuple.prototype.__gt__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: tuple() > ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: tuple() > ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>' not supported between instances of 'tuple' and '" + type_name(other) + "'"
+                )
+        }
     }
     if (this.length === 0 && other.length > 0) {
         return new types.Bool(false)
@@ -178,7 +214,19 @@ Tuple.prototype.__ge__ = function(other) {
     var types = require('../types')
 
     if (!types.isinstance(other, types.Tuple)) {
-        throw new exceptions.TypeError.$pyclass('unorderable types: tuple() >= ' + type_name(other) + '()')
+        switch(constants.BATAVIA_MAGIC) {
+            case constants.BATAVIA_MAGIC_34:
+            case constants.BATAVIA_MAGIC_35a0:
+            case constants.BATAVIA_MAGIC_35:
+            case constants.BATAVIA_MAGIC_353:
+                throw new exceptions.TypeError.$pyclass(
+                    'unorderable types: tuple() >= ' + type_name(other) + '()'
+                )
+            case constants.BATAVIA_MAGIC_36:
+                throw new exceptions.TypeError.$pyclass(
+                    "'>=' not supported between instances of 'tuple' and '" + type_name(other) + "'"
+                )
+        }
     }
     for (var i = 0; i < this.length; i++) {
         if (i >= other.length) {

--- a/tests/datatypes/test_bytes.py
+++ b/tests/datatypes/test_bytes.py
@@ -104,6 +104,23 @@ class UnaryBytesOperationTests(UnaryOperationTestCase, TranspileTestCase):
 class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'bytes'
 
+    not_implemented_versions = {
+        'test_subscr_bytearray': ['3.4'],
+        'test_subscr_bytes': ['3.4'],
+        'test_subscr_class': ['3.4'],
+        'test_subscr_complex': ['3.4'],
+        'test_subscr_dict': ['3.4'],
+        'test_subscr_float': ['3.4'],
+        'test_subscr_frozenset': ['3.4'],
+        'test_subscr_list': ['3.4'],
+        'test_subscr_None': ['3.4'],
+        'test_subscr_NotImplemented': ['3.4'],
+        'test_subscr_range': ['3.4'],
+        'test_subscr_set': ['3.4'],
+        'test_subscr_str': ['3.4'],
+        'test_subscr_tuple': ['3.4'],
+    }
+
     not_implemented = [
 
         'test_add_bytearray',
@@ -235,22 +252,8 @@ class BinaryBytesOperationTests(BinaryOperationTestCase, TranspileTestCase):
         'test_rshift_tuple',
 
         'test_subscr_bool',
-        'test_subscr_bytearray',
-        'test_subscr_bytes',
-        'test_subscr_class',
-        'test_subscr_complex',
-        'test_subscr_dict',
-        'test_subscr_float',
-        'test_subscr_frozenset',
         'test_subscr_int',
-        'test_subscr_list',
-        'test_subscr_None',
-        'test_subscr_NotImplemented',
-        'test_subscr_range',
-        'test_subscr_set',
         'test_subscr_slice',
-        'test_subscr_str',
-        'test_subscr_tuple',
 
         'test_subtract_bytearray',
         'test_subtract_class',

--- a/tests/datatypes/test_dict.py
+++ b/tests/datatypes/test_dict.py
@@ -33,11 +33,16 @@ class DictTests(TranspileTestCase):
             print(x)
             """)
 
+        subst = {
+            'str() < int()': ['int() < str()'],
+            "'str' and 'int'": ["'int' and 'str'"],
+        }
+
         # keys with the same string representation
         self.assertCodeExecution("""
             x = {1: 2, '1': 1}
             print(sorted(x.items()))
-        """, substitutions={'str() < int()': ['int() < str()']})
+        """, substitutions=subst)
 
     def test_getitem(self):
         # Simple existent key

--- a/tests/modules/test_json/test_decoding.py
+++ b/tests/modules/test_json/test_decoding.py
@@ -4,6 +4,11 @@ from .JSON_data import pass_data, fail_data
 
 # TODO(abonie): refactor to facilitate code reuse
 class LoadsTests(ModuleFunctionTestCase, TranspileTestCase):
+
+    not_implemented_versions = {
+        'test_fail': ['3.5', '3.6']
+    }
+
     def test_pass(self):
         for data in pass_data:
             self.assertCodeExecution(
@@ -110,6 +115,11 @@ class LoadsTests(ModuleFunctionTestCase, TranspileTestCase):
 
 
 class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
+
+    not_implemented_versions = {
+        'test_fail': ['3.5', '3.6']
+    }
+
     fp_def = """class fp:
     def __init__(self, doc):
         self.doc = doc
@@ -259,6 +269,11 @@ class LoadTests(ModuleFunctionTestCase, TranspileTestCase):
 
 
 class JSONDecoderTests(ModuleFunctionTestCase, TranspileTestCase):
+
+    not_implemented_versions = {
+        'test_fail': ['3.5', '3.6']
+    }
+
     def test_pass(self):
         for data in pass_data:
             self.assertCodeExecution(

--- a/tests/modules/test_json/test_encoding.py
+++ b/tests/modules/test_json/test_encoding.py
@@ -48,9 +48,10 @@ class JSONEncoderTests(MethodTestCase, TranspileTestCase):
                 print(e)
         """)
 
-    not_implemented = [
-        'test_json_JSONEncoder_encode_class',  # fails due to class __str__
-    ]
+    not_implemented_versions = {
+        # fails due to class __str__
+        'test_json_JSONEncoder_encode_class': ['3.4', '3.5'],
+    }
 
     is_flakey = [
         'test_json_JSONEncoder_encode_dict',   # fails due to dict ordering
@@ -62,9 +63,10 @@ JSONEncoderTests.add_one_arg_method_tests('json', 'JSONEncoder', ['encode'])
 
 class DumpsTests(ModuleFunctionTestCase, TranspileTestCase):
 
-    not_implemented = [
-        'test_json_dumps_class',  # fails due to class __str__
-    ]
+    not_implemented_versions = {
+        # fails due to class __str__
+        'test_json_dumps_class': ['3.4', '3.5'],
+    }
 
     is_flakey = [
         'test_json_dumps_dict',   # fails due to dict ordering

--- a/tests/modules/test_math.py
+++ b/tests/modules/test_math.py
@@ -1,9 +1,15 @@
 import sys
-from unittest import skipUnless
+from unittest import skipUnless, expectedFailure
 
 from ..utils import ModuleFunctionTestCase, TranspileTestCase
 
+
 class MathTests(ModuleFunctionTestCase, TranspileTestCase):
+
+    not_implemented_versions = {
+        'test_docstrings': ['3.5', '3.6'],
+    }
+
     substitutions = {
         # A
         '7.32747...e-15': [
@@ -171,6 +177,7 @@ class MathTests(ModuleFunctionTestCase, TranspileTestCase):
         print(math.trunc.__doc__)
         """)
 
+    @expectedFailure
     @skipUnless(sys.version_info >= (3, 5), reason="Need CPython 3.5")
     def test_docstrings_35(self):
         self.assertCodeExecution("""
@@ -178,7 +185,6 @@ class MathTests(ModuleFunctionTestCase, TranspileTestCase):
         print(math.gcd.__doc__)
         print(math.isclose.__doc__)
         """)
-
 
     def test_big_log(self):
         self.assertCodeExecution("""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -770,7 +770,7 @@ class NotImplementedToExpectedFailure:
 
         not_implemented_versions = getattr(self, 'not_implemented_versions', {})
         if method_name in not_implemented_versions:
-            py_version = float("%s.%s" % (sys.version_info.major, sys.version_info.minor))
+            py_version = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
             if py_version in not_implemented_versions[method_name]:
                 return True
 


### PR DESCRIPTION
There are multiple discrepancies in error messages for Python 3.5+, which causes 3.5 and 3.6 test suites to fail. This tries to fix them.