### PR TITLE
Fix YIELD_FROM for Python 3.6+

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -2017,7 +2017,11 @@ VirtualMachine.prototype.byte_YIELD_FROM = function() {
             throw e
         }
     }
-    this.jump(this.frame.f_lasti - 1)
+    if (constants.BATAVIA_MAGIC === constants.BATAVIA_MAGIC_36) {
+        this.jump(this.frame.f_lasti - 2)
+    } else {
+        this.jump(this.frame.f_lasti - 1)
+    }
     return 'yield'
 }
 


### PR DESCRIPTION
At the end of executing YIELD_FROM opcode instruction counter is
decremented to point at the previous instruction. Since Python 3.6 is
using 2-byte opcodes we have to decrement instruction counter by 2.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
