### PR TITLE
Added cache-loader for WebPack for quicker batavia.js builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ npm-debug.log
 
 # local environment configuration
 .env
+/.cache-loader/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "python compile_stdlib.py",
     "prepublishOnly": "pandoc --from=rst --to=markdown_github README.rst -o README.md",
     "build": "node_modules/.bin/webpack --progress",
+    "build:noCache": "DISABLE_WEBPACK_CACHE=true node_modules/.bin/webpack --progress",
     "watch": "node_modules/.bin/webpack --progress --watch",
     "serve": "node_modules/.bin/webpack-dev-server --inline --hot --port 3000",
     "lint": "node_modules/.bin/eslint batavia"
@@ -33,6 +34,7 @@
     "babel-core": "6.18.2",
     "babel-loader": "6.2.8",
     "babel-preset-env": "^1.4.0",
+    "cache-loader": "^1.0.3",
     "eslint": "3.9.1",
     "eslint-config-standard": "6.2.1",
     "eslint-loader": "1.6.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,17 @@
 var path = require('path')
 var webpack = require('webpack')
 
+var cachingDisabled = process.env.DISABLE_WEBPACK_CACHE !== undefined
+
+var javascriptLoaders = [{ loader: 'cache-loader' }, { loader: 'babel-loader' }]
+
+if (cachingDisabled) {
+    console.log('Caching is disabled.')
+    javascriptLoaders.shift()
+} else {
+    console.log('Caching is enabled.')
+}
+
 module.exports = {
     entry: {
         'batavia': './batavia/batavia.js'
@@ -25,11 +36,7 @@ module.exports = {
         rules: [
             {
                 test: /\.js$/,
-                use: [
-                    {
-                        loader: 'babel-loader'
-                    }
-                ],
+                use: javascriptLoaders,
                 exclude: '/node_modules/'
             }
         ]


### PR DESCRIPTION
I have added `cache-loader` to the WebPack config to reduce the time it takes to build batavia.js. Caching can be disabled by setting the `DISABLE_WEBPACK_CACHE` environment variable. I have also added an npm run script `build:noCache`  that sets this environment variable before building.

Currently (on my system) the `npm run build` process takes around 7 seconds. With this change the build time is reduced to under 1.5 seconds once the cache has been built. This reduces time it takes to test changes to JavaScript code, since only the changes need to be built and tested.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
