### PR TITLE
Add multiplication operations to int

### DIFF
--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -474,6 +474,17 @@ Int.prototype.__mul__ = function(other) {
             result = result.__add__(other)
         }
         return result
+    } else if (types.isinstance(other, types.Bytes)) {
+        if (this.val.gt(MAX_INT.val) || this.val.lt(MIN_INT.val)) {
+            throw new exceptions.OverflowError.$pyclass("cannot fit 'int' into an index-sized integer")
+        }
+        if ((other.__len__() <= 0) || (this.valueOf() <= 0)) {
+            return new types.Bytes('')
+        }
+        if (this.valueOf() > 4294967295) {
+            throw new exceptions.OverflowError.$pyclass('repeated bytes are too long')
+        }
+        return other.__mul__(this)
     } else if (types.isinstance(other, types.Complex)) {
         if (this.val.gt(MAX_INT.val) || this.val.lt(MIN_INT.val)) {
             throw new exceptions.OverflowError.$pyclass('int too large to convert to float')

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -485,6 +485,21 @@ Int.prototype.__mul__ = function(other) {
             throw new exceptions.OverflowError.$pyclass('repeated bytes are too long')
         }
         return other.__mul__(this)
+    } else if (types.isinstance(other, types.Bytearray)) {
+        if (this.val.gt(MAX_INT.val) || this.val.lt(MIN_INT.val)) {
+            throw new exceptions.OverflowError.$pyclass("cannot fit 'int' into an index-sized integer")
+        }
+        if ((other.length <= 0) || (this.valueOf() <= 0)) {
+            return new types.Bytearray('')
+        }
+        if (this.valueOf() > 4294967295) {
+            throw new exceptions.MemoryError.$pyclass('')
+        }
+        result = new types.Bytearray('')
+        for (i = 0; i < this.valueOf(); i++) {
+            result = new types.Bytearray(result.valueOf() + other.valueOf())
+        }
+        return result
     } else if (types.isinstance(other, types.Complex)) {
         if (this.val.gt(MAX_INT.val) || this.val.lt(MIN_INT.val)) {
             throw new exceptions.OverflowError.$pyclass('int too large to convert to float')

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -63,7 +63,6 @@ class BinaryIntOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
     not_implemented = [
         'test_multiply_bytearray',
-        'test_multiply_bytes',
         'test_multiply_complex',
 
         'test_power_complex',

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -62,7 +62,6 @@ class BinaryIntOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'int'
 
     not_implemented = [
-        'test_multiply_bytearray',
         'test_multiply_complex',
 
         'test_power_complex',
@@ -83,8 +82,6 @@ class InplaceIntOperationTests(InplaceOperationTestCase, TranspileTestCase):
 
         'test_modulo_complex',
 
-        'test_multiply_bytearray',
-        'test_multiply_bytes',
         'test_multiply_complex',
 
         'test_power_complex',


### PR DESCRIPTION
This add `bytes` and `bytearray` to int's multiplication operations.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
