### PR TITLE
Operator overloads

### DIFF
--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -153,7 +153,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__pow__(items[1]))
                         } else if (items[0].__pow__) {
-                            this.push(items[0].__pow__(items[1]))
+                            if (items[0].__pow__.__call__) {
+                                this.push(items[0].__pow__.__call__(items))
+                            } else {
+                                this.push(items[0].__pow__(items[1]))
+                            }
                         } else {
                             this.push(Math.pow(items[0], items[1]))
                         }
@@ -164,7 +168,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__mul__(items[1]))
                         } else if (items[0].__mul__) {
-                            this.push(items[0].__mul__(items[1]))
+                            if (items[0].__mul__.__call__) {
+                                this.push(items[0].__mul__.__call__(items))
+                            } else {
+                                this.push(items[0].__mul__(items[1]))
+                            }
                         } else {
                             this.push(items[0] * items[1])
                         }
@@ -175,7 +183,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__mod__(items[1]))
                         } else if (items[0].__mod__) {
-                            this.push(items[0].__mod__(items[1]))
+                            if (items[0].__mod__.__call__) {
+                                this.push(items[0].__mod__.__call__(items))
+                            } else {
+                                this.push(items[0].__mod__(items[1]))
+                            }
                         } else {
                             this.push(items[0] % items[1])
                         }
@@ -186,7 +198,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__add__(items[1]))
                         } else if (items[0].__add__) {
-                            this.push(items[0].__add__(items[1]))
+                            if (items[0].__add__.__call__) {
+                                this.push(items[0].__add__.__call__(items))
+                            } else {
+                                this.push(items[0].__add__(items[1]))
+                            }
                         } else {
                             this.push(items[0] + items[1])
                         }
@@ -197,7 +213,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__sub__(items[1]))
                         } else if (items[0].__sub__) {
-                            this.push(items[0].__sub__(items[1]))
+                            if (items[0].__sub__.__call__) {
+                                this.push(items[0].__sub__.__call__(items))
+                            } else {
+                                this.push(items[0].__sub__(items[1]))
+                            }
                         } else {
                             this.push(items[0] - items[1])
                         }
@@ -208,7 +228,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__getitem__(items[1]))
                         } else if (items[0].__getitem__) {
-                            this.push(items[0].__getitem__(items[1]))
+                            if (items[0].__getitem__.__call__) {
+                                this.push(items[0].__getitem__.__call__(items))
+                            } else {
+                                this.push(items[0].__getitem__(items[1]))
+                            }
                         } else {
                             this.push(items[0][items[1]])
                         }
@@ -219,7 +243,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__floordiv__(items[1]))
                         } else if (items[0].__floordiv__) {
-                            this.push(items[0].__floordiv__(items[1]))
+                            if (items[0].__floordiv__.__call__) {
+                                this.push(items[0].__floordiv__.__call__(items))
+                            } else {
+                                this.push(items[0].__floordiv__(items[1]))
+                            }
                         } else {
                             this.push(items[0] / items[1])
                         }
@@ -230,7 +258,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__truediv__(items[1]))
                         } else if (items[0].__truediv__) {
-                            this.push(items[0].__truediv__(items[1]))
+                            if (items[0].__truediv__.__call__) {
+                                this.push(items[0].__truediv__.__call__(items))
+                            } else {
+                                this.push(items[0].__truediv__(items[1]))
+                            }
                         } else {
                             this.push(items[0] / items[1])
                         }
@@ -241,7 +273,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__lshift__(items[1]))
                         } else if (items[0].__lshift__) {
-                            this.push(items[0].__lshift__(items[1]))
+                            if (items[0].__lshift__.__call__) {
+                                this.push(items[0].__lshift__.__call__(items))
+                            } else {
+                                this.push(items[0].__lshift__(items[1]))
+                            }
                         } else {
                             this.push(items[0] << items[1])
                         }
@@ -252,7 +288,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__rshift__(items[1]))
                         } else if (items[0].__rshift__) {
-                            this.push(items[0].__rshift__(items[1]))
+                            if (items[0].__rshift__.__call__) {
+                                this.push(items[0].__rshift__.__call__(items))
+                            } else {
+                                this.push(items[0].__rshift__(items[1]))
+                            }
                         } else {
                             this.push(items[0] >> items[1])
                         }
@@ -263,7 +303,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__and__(items[1]))
                         } else if (items[0].__and__) {
-                            this.push(items[0].__and__(items[1]))
+                            if (items[0].__and__.__call__) {
+                                this.push(items[0].__and__.__call__(items))
+                            } else {
+                                this.push(items[0].__and__(items[1]))
+                            }
                         } else {
                             this.push(items[0] & items[1])
                         }
@@ -274,7 +318,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__xor__(items[1]))
                         } else if (items[0].__xor__) {
-                            this.push(items[0].__xor__(items[1]))
+                            if (items[0].__xor__.__call__) {
+                                this.push(items[0].__xor__.__call__(items))
+                            } else {
+                                this.push(items[0].__xor__(items[1]))
+                            }
                         } else {
                             this.push(items[0] ^ items[1])
                         }
@@ -285,7 +333,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             this.push(types.NoneType.__or__(items[1]))
                         } else if (items[0].__or__) {
-                            this.push(items[0].__or__(items[1]))
+                            if (items[0].__or__.__call__) {
+                                this.push(items[0].__or__.__call__(items))
+                            } else {
+                                this.push(items[0].__or__(items[1]))
+                            }
                         } else {
                             this.push(items[0] | items[1])
                         }
@@ -534,7 +586,7 @@ VirtualMachine.prototype.run = function(tag, args) {
         }
 
         // Run the code
-        return this.run_code({'code': code})
+        return this.run_code({ 'code': code })
     } catch (e) {
         if (e instanceof builtins.BataviaError.$pyclass) {
             sys.stderr.write([e.msg + '\n'])
@@ -631,7 +683,7 @@ VirtualMachine.prototype.push_at = function(val, i) {
  * Pop a number of values from the value stack.
  *
  * A list of `n` values is returned, the deepest value first.
-*/
+ */
 VirtualMachine.prototype.popn = function(n) {
     if (n) {
         return this.frame.stack.splice(this.frame.stack.length - n, n)
@@ -837,7 +889,7 @@ VirtualMachine.prototype.unpack_code = function(code) {
                 lo = code.co_code.val[pos++]
                 hi = code.co_code.val[pos++]
                 extra = (lo << 16) | (hi << 24)
-                // emulate NOP
+                    // emulate NOP
                 unpacked_code[opcode_start_pos] = {
                     'opoffset': opcode_start_pos,
                     'opcode': dis.NOP,
@@ -957,7 +1009,7 @@ VirtualMachine.prototype.unwind_block = function(block) {
 
     if (block.type === 'except-handler') {
         this.popn(3)
-        // we don't need to set the last_exception, as it was handled
+            // we don't need to set the last_exception, as it was handled
     }
 }
 
@@ -999,15 +1051,15 @@ VirtualMachine.prototype.manage_block_stack = function(why) {
     }
 
     if (why === 'exception' &&
-            (block.type === 'setup-except' || block.type === 'finally')) {
+        (block.type === 'setup-except' || block.type === 'finally')) {
         this.push_block('except-handler')
         var exc = this.last_exception
-        // clear the last_exception so that we know it is handled
+            // clear the last_exception so that we know it is handled
         this.last_exception = null
         this.push(exc.traceback)
         this.push(exc.value)
         this.push(exc.exc_type)
-        // PyErr_Normalize_Exception goes here
+            // PyErr_Normalize_Exception goes here
         this.push(exc.traceback)
         this.push(exc.value)
         this.push(exc.exc_type)
@@ -1168,7 +1220,7 @@ VirtualMachine.prototype.byte_LOAD_NAME = function(name) {
         val = frame.f_globals[name]
     } else if (name in frame.f_builtins) {
         val = frame.f_builtins[name]
-        // Functions loaded from builtins need to be bound to this VM.
+            // Functions loaded from builtins need to be bound to this VM.
         if (val instanceof Function) {
             var doc = val.__doc__
             val = val.bind(this)
@@ -1216,7 +1268,7 @@ VirtualMachine.prototype.byte_LOAD_GLOBAL = function(name) {
         val = this.frame.f_globals[name]
     } else if (name in this.frame.f_builtins) {
         val = this.frame.f_builtins[name]
-        // Functions loaded from builtins need to be bound to this VM.
+            // Functions loaded from builtins need to be bound to this VM.
         if (val instanceof Function) {
             var doc = val.__doc__
             val = val.bind(this)
@@ -1275,7 +1327,8 @@ VirtualMachine.prototype.byte_COMPARE_OP = function(opnum) {
     if (opnum === 6) { // x in None
         if (items[1] === null) {
             result = types.NoneType.__contains__(items[0])
-        } if (items[1].__contains__) {
+        }
+        if (items[1].__contains__) {
             result = items[1].__contains__(items[0])
         } else {
             result = (items[0] in items[1])
@@ -1728,7 +1781,7 @@ VirtualMachine.prototype.do_raise = function(exc, cause) {
         exc_type = exc.__class__
         val = exc
     } else if (exc.$pyclass.prototype instanceof builtins.BaseException.$pyclass ||
-               exc.$pyclass === builtins.BaseException.$pyclass) {
+        exc.$pyclass === builtins.BaseException.$pyclass) {
         exc_type = exc
         val = new exc_type.$pyclass()
     } else {
@@ -1795,7 +1848,7 @@ VirtualMachine.prototype.byte_WITH_CLEANUP = function() {
     var ret = callables.call_method(mgr, '__exit__', [exc, val, tb])
     if (version.earlier('3.5a0')) {
         if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
-                ret.__bool__().valueOf()) {
+            ret.__bool__().valueOf()) {
             this.push('silenced')
         }
     } else {
@@ -1815,7 +1868,7 @@ VirtualMachine.prototype.byte_WITH_CLEANUP_FINISH = function() {
     var ret = this.pop()
     var exc = this.pop()
     if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
-            ret.__bool__().valueOf()) {
+        ret.__bool__().valueOf()) {
         this.push('silenced')
     }
 }
@@ -1978,7 +2031,7 @@ VirtualMachine.prototype.byte_YIELD_FROM = function() {
 
     try {
         if (types.isinstance(v, types.NoneType) ||
-                !types.isinstance(receiver, types.Generator)) {
+            !types.isinstance(receiver, types.Generator)) {
             this.return_value = callables.call_method(receiver, '__next__', [])
         } else {
             this.return_value = receiver.send(v)
@@ -2004,8 +2057,7 @@ VirtualMachine.prototype.byte_IMPORT_NAME = function(name) {
     var items = this.popn(2)
     this.push(
         builtins.__import__.apply(
-            this,
-            [
+            this, [
                 [name, this.frame.f_globals, this.frame.f_locals, items[1], items[0]],
                 null
             ]
@@ -2035,8 +2087,8 @@ VirtualMachine.prototype.byte_IMPORT_STAR = function() {
 
 VirtualMachine.prototype.byte_IMPORT_FROM = function(name) {
     var mod = this.top()
-    // Although modules may not be native, the native getattr works
-    // because it's a simple object subscript.
+        // Although modules may not be native, the native getattr works
+        // because it's a simple object subscript.
     var val = native.getattr(mod, name)
     this.push(val)
 }
@@ -2051,12 +2103,15 @@ var make_class = function(vm) {
         var func = args[0]
         var name = args[1]
         var bases = kwargs.bases || args.slice(2, args.length)
-        // var metaclass = kwargs.metaclass || args[3];
-        // var kwds = kwargs.kwds || args[4] || [];
+            // var metaclass = kwargs.metaclass || args[3];
+            // var kwds = kwargs.kwds || args[4] || [];
 
         // Create a locals context, and run the class function in it.
         var locals = new types.Dict()
-        func.__call__.apply(this, [[], [], locals])
+        func.__call__.apply(this, [
+            [],
+            [], locals
+        ])
 
         // Now construct the class, based on the constructed local context.
         // The *Javascript* constructor isn't the same as the *Python*
@@ -2126,7 +2181,6 @@ VirtualMachine.prototype.byte_SET_LINENO = function(lineno) {
     this.frame.f_lineno = lineno
 }
 
-VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {
-}
+VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {}
 
 module.exports = VirtualMachine

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -355,7 +355,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__ifloordiv__(items[1])
                         } else if (items[0].__ifloordiv__) {
-                            result = items[0].__ifloordiv__(items[1])
+                            if (items[0].__ifloordiv__.__call__) {
+                                result = items[0].__ifloordiv__.__call__(items)
+                            } else {
+                                result = items[0].__ifloordiv__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -372,7 +376,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__itruediv__(items[1])
                         } else if (items[0].__itruediv__) {
-                            result = items[0].__itruediv__(items[1])
+                            if (items[0].__itruediv__.__call__) {
+                                result = items[0].__itruediv__.__call__(items)
+                            } else {
+                                result = items[0].__itruediv__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -389,7 +397,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__iadd__(items[1])
                         } else if (items[0].__iadd__) {
-                            result = items[0].__iadd__(items[1])
+                            if (items[0].__iadd__.__call__) {
+                                result = items[0].__iadd__.__call__(items)
+                            } else {
+                                result = items[0].__iadd__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -406,7 +418,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__isub__(items[1])
                         } else if (items[0].__isub__) {
-                            result = items[0].__isub__(items[1])
+                            if (items[0].__isub__.__call__) {
+                                result = items[0].__isub__.__call__(items)
+                            } else {
+                                result = items[0].__isub__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -423,7 +439,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__imul__(items[1])
                         } else if (items[0].__imul__) {
-                            result = items[0].__imul__(items[1])
+                            if (items[0].__imul__.__call__) {
+                                result = items[0].__imul__.__call__(items)
+                            } else {
+                                result = items[0].__imul__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -440,7 +460,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__imod__(items[1])
                         } else if (items[0].__imod__) {
-                            result = items[0].__imod__(items[1])
+                            if (items[0].__imod__.__call__) {
+                                result = items[0].__imod__.__call__(items)
+                            } else {
+                                result = items[0].__imod__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -457,7 +481,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__ipow__(items[1])
                         } else if (items[0].__ipow__) {
-                            result = items[0].__ipow__(items[1])
+                            if (items[0].__ipow__.__call__) {
+                                result = items[0].__ipow__.__call__(items)
+                            } else {
+                                result = items[0].__ipow__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -474,7 +502,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__ilshift__(items[1])
                         } else if (items[0].__ilshift__) {
-                            result = items[0].__ilshift__(items[1])
+                            if (items[0].__ilshift__.__call__) {
+                                result = items[0].__ilshift__.__call__(items)
+                            } else {
+                                result = items[0].__ilshift__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -491,7 +523,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__irshift__(items[1])
                         } else if (items[0].__irshift__) {
-                            result = items[0].__irshift__(items[1])
+                            if (items[0].__irshift__.__call__) {
+                                result = items[0].__irshift__.__call__(items)
+                            } else {
+                                result = items[0].__irshift__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -508,7 +544,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__iand__(items[1])
                         } else if (items[0].__iand__) {
-                            result = items[0].__iand__(items[1])
+                            if (items[0].__iand__.__call__) {
+                                result = items[0].__iand__.__call__(items)
+                            } else {
+                                result = items[0].__iand__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -525,7 +565,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__ixor__(items[1])
                         } else if (items[0].__ixor__) {
-                            result = items[0].__ixor__(items[1])
+                            if (items[0].__ixor__.__call__) {
+                                result = items[0].__ixor__.__call__(items)
+                            } else {
+                                result = items[0].__ixor__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }
@@ -542,7 +586,11 @@ VirtualMachine.prototype.build_dispatch_table = function() {
                         if (items[0] === null) {
                             result = types.NoneType.__ior__(items[1])
                         } else if (items[0].__ior__) {
-                            result = items[0].__ior__(items[1])
+                            if (items[0].__ior__.__call__) {
+                                result = items[0].__ior__.__call__(items)
+                            } else {
+                                result = items[0].__ior__(items[1])
+                            }
                             if (result === null) {
                                 result = items[0]
                             }

--- a/batavia/VirtualMachine.js
+++ b/batavia/VirtualMachine.js
@@ -634,7 +634,7 @@ VirtualMachine.prototype.run = function(tag, args) {
         }
 
         // Run the code
-        return this.run_code({ 'code': code })
+        return this.run_code({'code': code})
     } catch (e) {
         if (e instanceof builtins.BataviaError.$pyclass) {
             sys.stderr.write([e.msg + '\n'])
@@ -731,7 +731,7 @@ VirtualMachine.prototype.push_at = function(val, i) {
  * Pop a number of values from the value stack.
  *
  * A list of `n` values is returned, the deepest value first.
- */
+*/
 VirtualMachine.prototype.popn = function(n) {
     if (n) {
         return this.frame.stack.splice(this.frame.stack.length - n, n)
@@ -937,7 +937,7 @@ VirtualMachine.prototype.unpack_code = function(code) {
                 lo = code.co_code.val[pos++]
                 hi = code.co_code.val[pos++]
                 extra = (lo << 16) | (hi << 24)
-                    // emulate NOP
+                // emulate NOP
                 unpacked_code[opcode_start_pos] = {
                     'opoffset': opcode_start_pos,
                     'opcode': dis.NOP,
@@ -1057,7 +1057,7 @@ VirtualMachine.prototype.unwind_block = function(block) {
 
     if (block.type === 'except-handler') {
         this.popn(3)
-            // we don't need to set the last_exception, as it was handled
+        // we don't need to set the last_exception, as it was handled
     }
 }
 
@@ -1099,15 +1099,15 @@ VirtualMachine.prototype.manage_block_stack = function(why) {
     }
 
     if (why === 'exception' &&
-        (block.type === 'setup-except' || block.type === 'finally')) {
+            (block.type === 'setup-except' || block.type === 'finally')) {
         this.push_block('except-handler')
         var exc = this.last_exception
-            // clear the last_exception so that we know it is handled
+        // clear the last_exception so that we know it is handled
         this.last_exception = null
         this.push(exc.traceback)
         this.push(exc.value)
         this.push(exc.exc_type)
-            // PyErr_Normalize_Exception goes here
+        // PyErr_Normalize_Exception goes here
         this.push(exc.traceback)
         this.push(exc.value)
         this.push(exc.exc_type)
@@ -1268,7 +1268,7 @@ VirtualMachine.prototype.byte_LOAD_NAME = function(name) {
         val = frame.f_globals[name]
     } else if (name in frame.f_builtins) {
         val = frame.f_builtins[name]
-            // Functions loaded from builtins need to be bound to this VM.
+        // Functions loaded from builtins need to be bound to this VM.
         if (val instanceof Function) {
             var doc = val.__doc__
             val = val.bind(this)
@@ -1316,7 +1316,7 @@ VirtualMachine.prototype.byte_LOAD_GLOBAL = function(name) {
         val = this.frame.f_globals[name]
     } else if (name in this.frame.f_builtins) {
         val = this.frame.f_builtins[name]
-            // Functions loaded from builtins need to be bound to this VM.
+        // Functions loaded from builtins need to be bound to this VM.
         if (val instanceof Function) {
             var doc = val.__doc__
             val = val.bind(this)
@@ -1375,8 +1375,7 @@ VirtualMachine.prototype.byte_COMPARE_OP = function(opnum) {
     if (opnum === 6) { // x in None
         if (items[1] === null) {
             result = types.NoneType.__contains__(items[0])
-        }
-        if (items[1].__contains__) {
+        } if (items[1].__contains__) {
             result = items[1].__contains__(items[0])
         } else {
             result = (items[0] in items[1])
@@ -1829,7 +1828,7 @@ VirtualMachine.prototype.do_raise = function(exc, cause) {
         exc_type = exc.__class__
         val = exc
     } else if (exc.$pyclass.prototype instanceof builtins.BaseException.$pyclass ||
-        exc.$pyclass === builtins.BaseException.$pyclass) {
+               exc.$pyclass === builtins.BaseException.$pyclass) {
         exc_type = exc
         val = new exc_type.$pyclass()
     } else {
@@ -1896,7 +1895,7 @@ VirtualMachine.prototype.byte_WITH_CLEANUP = function() {
     var ret = callables.call_method(mgr, '__exit__', [exc, val, tb])
     if (version.earlier('3.5a0')) {
         if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
-            ret.__bool__().valueOf()) {
+                ret.__bool__().valueOf()) {
             this.push('silenced')
         }
     } else {
@@ -1916,7 +1915,7 @@ VirtualMachine.prototype.byte_WITH_CLEANUP_FINISH = function() {
     var ret = this.pop()
     var exc = this.pop()
     if (!(exc instanceof types.NoneType) && ret.__bool__ !== undefined &&
-        ret.__bool__().valueOf()) {
+            ret.__bool__().valueOf()) {
         this.push('silenced')
     }
 }
@@ -2079,7 +2078,7 @@ VirtualMachine.prototype.byte_YIELD_FROM = function() {
 
     try {
         if (types.isinstance(v, types.NoneType) ||
-            !types.isinstance(receiver, types.Generator)) {
+                !types.isinstance(receiver, types.Generator)) {
             this.return_value = callables.call_method(receiver, '__next__', [])
         } else {
             this.return_value = receiver.send(v)
@@ -2105,7 +2104,8 @@ VirtualMachine.prototype.byte_IMPORT_NAME = function(name) {
     var items = this.popn(2)
     this.push(
         builtins.__import__.apply(
-            this, [
+            this,
+            [
                 [name, this.frame.f_globals, this.frame.f_locals, items[1], items[0]],
                 null
             ]
@@ -2135,8 +2135,8 @@ VirtualMachine.prototype.byte_IMPORT_STAR = function() {
 
 VirtualMachine.prototype.byte_IMPORT_FROM = function(name) {
     var mod = this.top()
-        // Although modules may not be native, the native getattr works
-        // because it's a simple object subscript.
+    // Although modules may not be native, the native getattr works
+    // because it's a simple object subscript.
     var val = native.getattr(mod, name)
     this.push(val)
 }
@@ -2151,15 +2151,12 @@ var make_class = function(vm) {
         var func = args[0]
         var name = args[1]
         var bases = kwargs.bases || args.slice(2, args.length)
-            // var metaclass = kwargs.metaclass || args[3];
-            // var kwds = kwargs.kwds || args[4] || [];
+        // var metaclass = kwargs.metaclass || args[3];
+        // var kwds = kwargs.kwds || args[4] || [];
 
         // Create a locals context, and run the class function in it.
         var locals = new types.Dict()
-        func.__call__.apply(this, [
-            [],
-            [], locals
-        ])
+        func.__call__.apply(this, [[], [], locals])
 
         // Now construct the class, based on the constructed local context.
         // The *Javascript* constructor isn't the same as the *Python*
@@ -2229,6 +2226,7 @@ VirtualMachine.prototype.byte_SET_LINENO = function(lineno) {
     this.frame.f_lineno = lineno
 }
 
-VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {}
+VirtualMachine.prototype.byte_EXTENDED_ARG = function(extra) {
+}
 
 module.exports = VirtualMachine

--- a/batavia/types/Int.js
+++ b/batavia/types/Int.js
@@ -402,6 +402,9 @@ Int.prototype.__truediv__ = function(other) {
         } else {
             return this.__truediv__(new Int(0))
         }
+    } else if (types.isinstance(other, types.Complex)) {
+        var castToComplex = new types.Complex(this.valueOf())
+        return castToComplex.__truediv__(other.valueOf())
     } else {
         throw new exceptions.TypeError.$pyclass("unsupported operand type(s) for /: 'int' and '" + type_name(other) + "'")
     }

--- a/tests/datatypes/test_bool.py
+++ b/tests/datatypes/test_bool.py
@@ -27,7 +27,6 @@ class BinaryBoolOperationTests(BinaryOperationTestCase, TranspileTestCase):
     data_type = 'bool'
 
     not_implemented = [
-        'test_true_divide_complex'
     ]
 
 
@@ -35,5 +34,4 @@ class InplaceBoolOperationTests(InplaceOperationTestCase, TranspileTestCase):
     data_type = 'bool'
 
     not_implemented = [
-        'test_true_divide_complex',
     ]

--- a/tests/structures/test_datamodel.py
+++ b/tests/structures/test_datamodel.py
@@ -1,0 +1,808 @@
+# coding=utf-8
+from ..utils import TranspileTestCase
+from unittest import expectedFailure
+
+class ClassBinaryOpsDataModelTests(TranspileTestCase):
+    def test_add(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __add__(self, other):
+                    x = self.x + other.x
+                    y = self.y + other.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            p2 = Pair(9, 4)
+
+            print(p1 + p2)    
+        """, run_in_function=False)
+
+    def test_subtract(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __sub__(self, other):
+                    x = self.x - other.x
+                    y = self.y - other.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            p2 = Pair(9, 4)
+
+            print(p1 - p2)    
+        """, run_in_function=False)
+
+    def test_multiply(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __mul__(self, other):
+                    x = self.x * other
+                    y = self.y * other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 * num)    
+        """, run_in_function=False)
+
+    def test_truedivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __truediv__(self, other):
+                    x = self.x / other
+                    y = self.y / other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 / num)    
+        """, run_in_function=False)
+
+    def test_floordivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __floordiv__(self, other):
+                    x = self.x // other
+                    y = self.y // other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 // num)    
+        """, run_in_function=False)
+
+    def test_mod(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __mod__(self, other):
+                    x = self.x % other
+                    y = self.y % other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 % num)    
+        """, run_in_function=False)
+
+    def test_pow(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __pow__(self, other):
+                    x = self.x ** other
+                    y = self.y ** other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 ** num)    
+        """, run_in_function=False)
+
+    def test_lshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __lshift__(self, other):
+                    x = self.x << other
+                    y = self.y << other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 << num)    
+        """, run_in_function=False)
+
+    def test_rshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rshift__(self, other):
+                    x = self.x >> other
+                    y = self.y >> other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            num = 4
+
+            print(p1 >> num)    
+        """, run_in_function=False)
+
+    def test_and(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __and__(self, other):
+                    x = self.x & other.x
+                    y = self.y & other.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            p2 = Pair(6, 5)
+            
+            print(p1 & p2)    
+        """, run_in_function=False)
+
+    def test_xor(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __xor__(self, other):
+                    x = self.x ^ other.x
+                    y = self.y ^ other.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            p2 = Pair(6, 5)
+            
+            print(p1 ^ p2)    
+        """, run_in_function=False)
+
+    def test_or(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __or__(self, other):
+                    x = self.x | other.x
+                    y = self.y | other.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+            p2 = Pair(6, 5)
+            
+            print(p1 | p2)    
+        """, run_in_function=False)
+
+
+class ClassInPlaceOpsDataModelTests(TranspileTestCase):
+    def test_iadd(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __iadd__(self, other):
+                    self.x += other.x
+                    self.y += other.y
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 += Pair(9, 4)
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_isubtract(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __isub__(self, other):
+                    self.x -= other.x
+                    self.y -= other.y
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 -= Pair(9, 4)
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_imultiply(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __imul__(self, other):
+                    self.x *= other
+                    self.y *= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 *= 4
+            
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_itruedivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __itruediv__(self, other):
+                    self.x /= other
+                    self.y /= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 /=4
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_ifloordivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ifloordiv__(self, other):
+                    self.x //= other
+                    self.y //= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 //= 4
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_imod(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __imod__(self, other):
+                    self.x %= other
+                    self.y %= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 %= 4
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_ipow(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ipow__(self, other):
+                    self.x **= other
+                    self.y **= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 **= 4
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_ilshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ilshift__(self, other):
+                    self.x <<= other
+                    self.y <<= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 <<= 2
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_irshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __irshift__(self, other):
+                    self.x >>= other
+                    self.y >>= other
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 >>= 2
+
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_iand(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __iand__(self, other):
+                    self.x &= other.x
+                    self.y &= other.y
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 &= Pair(6, 5)
+            
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_ixor(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ixor__(self, other):
+                    self.x ^= other.x
+                    self.y ^= other.y
+                    return self
+
+            p1 = Pair(5, 6)
+            p1 ^= Pair(6, 5)
+            
+            print(p1)    
+        """, run_in_function=False)
+
+    def test_ior(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ior__(self, other):
+                    self.x |= other.x
+                    self.y |= other.y
+                    return self
+
+            p1 = Pair(5, 6)
+            p2 |= Pair(6, 5)
+            
+            print(p1)    
+        """, run_in_function=False)
+
+@expectedFailure
+class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
+    def test_radd(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+            
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+            
+                def __radd__(self, other):
+                    x = self.x + other
+                    y = self.y + other
+                    return Pair(x, y)
+            
+            p1 = Pair(5, 6)
+            
+            print(4 + p1)
+        """, run_in_function=False)
+
+    def test_rsubtract(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+            
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+            
+                def __rsub__(self, other):
+                    x = other - self.x 
+                    y = other - self.y 
+                    return Pair(x, y)
+            
+            p1 = Pair(5, 6)
+            
+            print(4 - p1)
+        """, run_in_function=False)
+
+    def test_rmultiply(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rmul__(self, other):
+                    x = self.x * other
+                    y = self.y * other
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(3 * p1)    
+        """, run_in_function=False)
+
+    def test_rtruedivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rtruediv__(self, other):
+                    x = other / self.x
+                    y = other / self.y 
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 / p1)    
+        """, run_in_function=False)
+
+    def test_rfloordivision(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rfloordiv__(self, other):
+                    x = other // self.x 
+                    y = other // self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 // p1)    
+        """, run_in_function=False)
+
+    def test_rmod(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rmod__(self, other):
+                    x = other % self.x 
+                    y = other % self.y 
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 % p1)    
+        """, run_in_function=False)
+
+    def test_rpow(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rpow__(self, other):
+                    x = other ** self.x
+                    y = other ** self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 ** p1)    
+        """, run_in_function=False)
+
+    def test_rlshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rlshift__(self, other):
+                    x =  other << self.x
+                    y =  other << self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 << p1)    
+        """, run_in_function=False)
+
+    def test_rrshift(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rrshift__(self, other):
+                    x =  other >> self.x
+                    y =  other >> self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 >> p1)    
+        """, run_in_function=False)
+
+    def test_rand(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rand__(self, other):
+                    x = other & self.x
+                    y = other & self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 & p1)    
+        """, run_in_function=False)
+
+    def test_rxor(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __rxor__(self, other):
+                    x = other ^ self.x
+                    y = other ^ self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 ^ p1)    
+        """, run_in_function=False)
+
+    def test_ror(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __ror__(self, other):
+                    x = other | self.x
+                    y = other | self.y
+                    return Pair(x, y)
+
+            p1 = Pair(5, 6)
+
+            print(4 | p1) 
+        """, run_in_function=False)
+
+
+class ClassContainerDataModelTests(TranspileTestCase):
+    def test_getitem(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __getitem__(self, idx):
+                    if idx == 0 or idx == 'x' or idx == 'X':
+                        return self.x
+                    if idx == 1 or idx == 'y' or idx == 'Y':
+                        return self.y
+                    raise IndexError
+
+            p = Pair(5, 6)
+            
+            print('p[0] =', p[0])
+            print('p[0] =', p[1])
+            print('p["x"] =', p['x'])
+            print('p["X"] =', p['X'])
+            print('p["y"] =', p['y'])
+        """, run_in_function=False)
+
+    @expectedFailure
+    def test_setitem(self):
+        self.assertCodeExecution("""
+            class Pair:
+                def __init__(self, x, y):
+                    self.x = x
+                    self.y = y
+
+                def __str__(self):
+                    return "({}, {})".format(self.x, self.y)
+
+                def __setitem__(self, key, value):
+                    if key == 0 or key == 'x' or key == 'X':
+                        self.x = value
+                    elif key == 1 or key == 'y' or key == 'Y':
+                        self.y = value
+                    else:
+                        raise IndexError
+
+            p = Pair(5, 6)
+            
+            print(p)
+            p[1] = 11
+            print(p)
+            p['x'] = 2
+            print(p)            
+        """, run_in_function=False)


### PR DESCRIPTION
The Batavia VM will now check for user defined data model methods in addition to native JavaScript implementations. Currently most binary operations and in-place operations are implemented. Reversed binary operations and in place falling back to binary / reverse binary operations is NOT implemented. 
 
This will allow users to implement operator overloads methods such as ``__add__`` and subsequently use the add operator directly as ``obj1 + obj2``.  Refs #593 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
