### PR TITLE
Add set.union and set.intersection aliases to set.__ior__ and set.__i…

### DIFF
--- a/batavia/types/Set.js
+++ b/batavia/types/Set.js
@@ -489,6 +489,10 @@ Set.prototype.update = function(args) {
     }
 }
 
+// note that union and intersection are equivalent to __ior__ and __iand__
+Set.prototype.union = Set.prototype.__ior__
+Set.prototype.intersection = Set.prototype.__iand__
+
 /**************************************************
  * Module exports
  **************************************************/

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -62,6 +62,34 @@ class SetTests(TranspileTestCase):
             """)
 
 
+    def test__ior__(self):
+        self.assertCodeExecution("""
+        a = {'a', 'b', 'c'}
+        b = {'a', 'c', 'd'}
+        a.__ior__(b)
+        """)
+
+    def test__iand__(self):
+        self.assertEqual("""
+        a = {'a', 'b', 'c'}
+        b = {'a', 'c', 'd'}
+        a.__iand__(b)
+        """)
+
+
+    def test_union(self):
+        self.assertCodeExecution("""
+        a = {'a', 'b', 'c'}
+        b = {'a', 'c', 'd'}
+        a.union(b)        
+        """)
+
+    def test_intersection(self):
+        self.assertCodeExecution("""
+        a = {'a', 'b', 'c'}
+        b = {'a', 'c', 'd'}
+        a.intersection(b)
+        """)
 
 class UnarySetOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'set'

--- a/tests/datatypes/test_set.py
+++ b/tests/datatypes/test_set.py
@@ -70,7 +70,7 @@ class SetTests(TranspileTestCase):
         """)
 
     def test__iand__(self):
-        self.assertEqual("""
+        self.assertCodeExecution("""
         a = {'a', 'b', 'c'}
         b = {'a', 'c', 'd'}
         a.__iand__(b)


### PR DESCRIPTION
`set.union` and `set.intersection` are two frequently used methods of a set. Issue #478 added the `set.__ior__` and `set.__iand__` methods which are equivalent–although `.union` and `.intersection` are more standard (as they aren't dunder methods) and are used in a few modules in the python standard library.

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
