### PR TITLE
io module

### DIFF
--- a/batavia/modules.js
+++ b/batavia/modules.js
@@ -18,5 +18,6 @@ module.exports = {
     'time': require('./modules/time'),
     'random': require('./modules/random'),
     'webbrowser': require('./modules/webbrowser'),
-    'json': require('./modules/json')
+    'json': require('./modules/json'),
+	'io': require('./modules/io')
 }

--- a/batavia/modules/io.js
+++ b/batavia/modules/io.js
@@ -8,12 +8,11 @@ var type_name = require('../core').type_name
 var create_pyclass = require('../core').create_pyclass
 
 var io = {
-    '__doc__': '',
+    '__doc__': 'The io module provides the Python interfaces to stream handling. The\nbuiltin open function is defined in this module.\n\nAt the top of the I/O hierarchy is the abstract base class IOBase. It\ndefines the basic interface to a stream. Note, however, that there is no\nseparation between reading and writing to streams; implementations are\nallowed to raise an IOError if they do not support a given operation.\n\nExtending IOBase is RawIOBase which deals simply with the reading and\nwriting of raw bytes to a stream. FileIO subclasses RawIOBase to provide\nan interface to OS files.\n\nBufferedIOBase deals with buffering on a raw byte stream (RawIOBase). Its\nsubclasses, BufferedWriter, BufferedReader, and BufferedRWPair buffer\nstreams that are readable, writable, and both respectively.\nBufferedRandom provides a buffered interface to random access\nstreams. BytesIO is a simple stream of in-memory bytes.\n\nAnother IOBase subclass, TextIOBase, deals with the encoding and decoding\nof streams into text. TextIOWrapper, which extends it, is a buffered text\ninterface to a buffered raw stream (`BufferedIOBase`). Finally, StringIO\nis a in-memory stream for text.\n\nArgument names are not part of the specification, and only the arguments\nof open() are intended to be used as keyword arguments.\n\ndata:\n\nDEFAULT_BUFFER_SIZE\n\n   An int containing the default buffer size used by the module\'s buffered\n   I/O classes. open() uses the file\'s blksize (as obtained by os.stat) if\n   possible.\n',
     '__file__': 'batavia/modules/io.js',
     '__name__': 'io',
-    '__package__': 'The io module provides the Python interfaces to stream handling. The\nbuiltin open function is defined in this module.\n\nAt the top of the I/O hierarchy is the abstract base class IOBase. It\ndefines the basic interface to a stream. Note, however, that there is no\nseparation between reading and writing to streams; implementations are\nallowed to raise an IOError if they do not support a given operation.\n\nExtending IOBase is RawIOBase which deals simply with the reading and\nwriting of raw bytes to a stream. FileIO subclasses RawIOBase to provide\nan interface to OS files.\n\nBufferedIOBase deals with buffering on a raw byte stream (RawIOBase). Its\nsubclasses, BufferedWriter, BufferedReader, and BufferedRWPair buffer\nstreams that are readable, writable, and both respectively.\nBufferedRandom provides a buffered interface to random access\nstreams. BytesIO is a simple stream of in-memory bytes.\n\nAnother IOBase subclass, TextIOBase, deals with the encoding and decoding\nof streams into text. TextIOWrapper, which extends it, is a buffered text\ninterface to a buffered raw stream (`BufferedIOBase`). Finally, StringIO\nis a in-memory stream for text.\n\nArgument names are not part of the specification, and only the arguments\nof open() are intended to be used as keyword arguments.\n\ndata:\n\nDEFAULT_BUFFER_SIZE\n\n   An int containing the default buffer size used by the module\'s buffered\n   I/O classes. open() uses the file\'s blksize (as obtained by os.stat) if\n   possible.\n'
+    '__package__': ''
 }
-      
 
 io.IOBase = function(args, kwargs) {
 	var types = require('../types')
@@ -23,44 +22,58 @@ io.IOBase = function(args, kwargs) {
 
 create_pyclass(io.IOBase, 'IOBase')
 
-
 io.IOBase.__repr__ = function() {
-	return '<IOBase object at 0x99999999>';
+	return '<IOBase object at 0x99999999>'
 }
 
+// io files will never be equal unless they both reference the same object,
+// since they are types actively reading from the system and maintaining appropriate state
 io.IOBase.prototype.__eq__ = function(other) {
-	return this === other;
+	return this === other
 }
 
 io.IOBase.prototype.__ne__ = function(other) {
-	return this === other;
+	return this === other
 }
 
-// io.IOBase.prototype.name = '';
+io.IOBase.prototype.close = function() {
+	if (this.closed) {
+		this.flush()
+		this.closed = true
+	}
+	else {
+		// only the first call will have an effect; multiple close()
+		// operations allowed for convenience.
+	}
+}
+
+io.IOBase.prototype.closed = false
+
+io.IOBase.prototype.fileno = function() {
+    throw new exceptions.UnsupportedOperation.$pyclass(
+        'fileno'
+    )
+}
 
 io.IOBase.prototype.flush = function() {
-//
 }
-
-// io.IOBase.prototype.tell = function() {
-//
-// }
-//
-// io.IOBase.prototype.{
-//
-// }
 
 // since we're in Javascript, we're not in a TTY
 io.IOBase.prototype.isatty = function() {
-	return false;
+	return false
 }
 
-//io.IOBase.prototype.buffer =
-io.IOBase.prototype.softspace = 0
+io.IOBase.prototype.readable = function() {
+	return false
+}
 
-io.IOBase.prototype.readable = function() { return false  };  // IOBase isn't a read/write-able file; its a class
-io.IOBase.prototype.writeable = function(){ return false  }; // that files inherit and override
-io.IOBase.prototype.seekable = function() { return false  };
+io.IOBase.prototype.readline = function() {
+	
+}
+
+io.IOBase.prototype.readlines = function() {
+	
+}
 
 io.IOBase.prototype.seek = function() {
     throw new exceptions.UnsupportedOperation.$pyclass(
@@ -68,12 +81,63 @@ io.IOBase.prototype.seek = function() {
     )
 }
 
+io.IOBase.prototype.seekable = function() {
+	return false;
+}
+
+io.IOBase.prototype.tell = function() {
+    throw new exceptions.UnsupportedOperation.$pyclass(
+        'seek'
+    )
+}
+
+io.IOBase.prototype.truncate = function() {
+    throw new exceptions.UnsupportedOperation.$pyclass(
+        'truncate'
+    )
+}
+
 io.IOBase.prototype.fileno = function() {
-	// raise an unsupportedoperation exception
+	io.IOBase.prototype.tell = function() {
+	    throw new exceptions.UnsupportedOperation.$pyclass(
+	        'fileno'
+	    )
+	}
 }
 
-io.IOBase.prototype.xreadlines = function() {
 
+io.IOBase.prototype.softspace = 0
+
+io.IOBase.prototype.seekable = function() { return false }
+
+io.IOBase.prototype.writeable = function(){
+	return false
 }
+
+io.IOBase.prototype.writelines = function(lines) {
+	callables.iter_for_each(lines, function(line) {
+		// NOTE: writelines does not add newlines.
+		// This is equivalent to calling write() for each string. (from CPython io.writelines docstring)
+		this.write(line)
+	})
+}
+
+io.IOBase.prototype.__del__ = function() {
+	this.close();
+}
+
+// These functions intentionally commented out! IOBase is a
+// type that is only intended to be inherited from and does not have
+// a public constructor. Each instance of IOBase implements read() and write()
+// based on the actual object itself, which readlines(), writelines(), and xreadlines()
+// then use.
+
+// io.IOBase.prototype.read = function() {
+//
+// }
+//
+// io.IOBase.prototype.write = function() {
+//
+// }
 
 module.exports = io

--- a/batavia/modules/io.js
+++ b/batavia/modules/io.js
@@ -1,0 +1,79 @@
+var fs = require('localstorage-fs')
+
+var PyObject = require('../core').Object
+var exceptions = require('../core').exceptions
+var version = require('../core').version
+var callables = require('../core').callables
+var type_name = require('../core').type_name
+var create_pyclass = require('../core').create_pyclass
+
+var io = {
+    '__doc__': '',
+    '__file__': 'batavia/modules/io.js',
+    '__name__': 'io',
+    '__package__': 'The io module provides the Python interfaces to stream handling. The\nbuiltin open function is defined in this module.\n\nAt the top of the I/O hierarchy is the abstract base class IOBase. It\ndefines the basic interface to a stream. Note, however, that there is no\nseparation between reading and writing to streams; implementations are\nallowed to raise an IOError if they do not support a given operation.\n\nExtending IOBase is RawIOBase which deals simply with the reading and\nwriting of raw bytes to a stream. FileIO subclasses RawIOBase to provide\nan interface to OS files.\n\nBufferedIOBase deals with buffering on a raw byte stream (RawIOBase). Its\nsubclasses, BufferedWriter, BufferedReader, and BufferedRWPair buffer\nstreams that are readable, writable, and both respectively.\nBufferedRandom provides a buffered interface to random access\nstreams. BytesIO is a simple stream of in-memory bytes.\n\nAnother IOBase subclass, TextIOBase, deals with the encoding and decoding\nof streams into text. TextIOWrapper, which extends it, is a buffered text\ninterface to a buffered raw stream (`BufferedIOBase`). Finally, StringIO\nis a in-memory stream for text.\n\nArgument names are not part of the specification, and only the arguments\nof open() are intended to be used as keyword arguments.\n\ndata:\n\nDEFAULT_BUFFER_SIZE\n\n   An int containing the default buffer size used by the module\'s buffered\n   I/O classes. open() uses the file\'s blksize (as obtained by os.stat) if\n   possible.\n'
+}
+      
+
+io.IOBase = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.IOBase, 'IOBase')
+
+
+io.IOBase.__repr__ = function() {
+	return '<IOBase object at 0x99999999>';
+}
+
+io.IOBase.prototype.__eq__ = function(other) {
+	return this === other;
+}
+
+io.IOBase.prototype.__ne__ = function(other) {
+	return this === other;
+}
+
+// io.IOBase.prototype.name = '';
+
+io.IOBase.prototype.flush = function() {
+//
+}
+
+// io.IOBase.prototype.tell = function() {
+//
+// }
+//
+// io.IOBase.prototype.{
+//
+// }
+
+// since we're in Javascript, we're not in a TTY
+io.IOBase.prototype.isatty = function() {
+	return false;
+}
+
+//io.IOBase.prototype.buffer =
+io.IOBase.prototype.softspace = 0
+
+io.IOBase.prototype.readable = function() { return false  };  // IOBase isn't a read/write-able file; its a class
+io.IOBase.prototype.writeable = function(){ return false  }; // that files inherit and override
+io.IOBase.prototype.seekable = function() { return false  };
+
+io.IOBase.prototype.seek = function() {
+    throw new exceptions.UnsupportedOperation.$pyclass(
+        'seek'
+    )
+}
+
+io.IOBase.prototype.fileno = function() {
+	// raise an unsupportedoperation exception
+}
+
+io.IOBase.prototype.xreadlines = function() {
+
+}
+
+module.exports = io

--- a/batavia/modules/io.js
+++ b/batavia/modules/io.js
@@ -140,4 +140,78 @@ io.IOBase.prototype.__del__ = function() {
 //
 // }
 
+io.BufferedIOBase = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.BufferedIOBase, 'IOBase')
+
+io.FileIO = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.FileIO, 'FileIO')
+
+io.BytesIO = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.BytesIO, 'BytesIO')
+
+io.BufferedReader = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.BufferedReader, 'BufferedReader')
+
+io.BufferedWriter = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.BufferedWriter, 'BufferedWriter')
+
+io.TextIOBase = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.BufferedWriter, 'BufferedWriter')
+
+io.TextIOWrapper = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.TextIOWrapper, 'TextIOWrapper')
+
+
+io.StringIO = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.StringIO, 'StringIO')
+
+io.IncrementalNewlineDecoder = function(args, kwargs) {
+	var types = require('../types')
+
+	PyObject.call(this)
+}
+
+create_pyclass(io.IncrementalNewlineDecoder, 'IncrementalNewlineDecoder')
+
+
 module.exports = io

--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,6 +1008,30 @@
       "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
       "dev": true
     },
+    "cache-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-1.1.0.tgz",
+      "integrity": "sha512-3shBzq11ESBqD8sTBrn0+yDZsVwpnBfy1EdDZdn2faWKRxOcwa0sDo5fmtv7H9NUUZsmzyl5z/BfWv9JJuYXcw==",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2003,6 +2027,11 @@
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
+    "fs-stats": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/fs-stats/-/fs-stats-0.0.0.tgz",
+      "integrity": "sha1-i+clkYLwCU4pyD8JhD3JLEG3EWg="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2680,13 +2709,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2694,6 +2716,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3391,6 +3420,21 @@
         "emojis-list": "2.1.0",
         "json5": "0.5.1",
         "object-assign": "4.1.1"
+      }
+    },
+    "localstorage-fs": {
+      "version": "git://github.com/lschumm/localstorage-fs.git#f54f1858e7faae470abb2e636409836665a978ee",
+      "requires": {
+        "fs-stats": "0.0.0",
+        "inherits": "2.0.3",
+        "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
       }
     },
     "lodash": {
@@ -4569,14 +4613,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4585,6 +4621,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "base64-js": "1.2.0",
     "bignumber.js": "2.4.0",
     "buffer": "5.0.0",
+    "localstorage-fs": "git://github.com/lschumm/localstorage-fs.git#f54f185",
     "moment": "2.17.0",
     "moment-timezone": "0.5.10",
     "webpack": "2.2.1"


### PR DESCRIPTION
In this PR, I add the io module to Batavia.

Although one may naively implement the `open()` call as a standalone entity, a lot of Python depends on IO buffers–meaning that the io module is important for a lot more than files. Emulating a filesystem is very useful in porting system scripts to the browser, allowing for easy data storage (by allowing `pickle` or similar to write to what it wants to see, a writable file object).

## PR Checklist:
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct


*NOTE: this is in progress! Please don't merge yet :)*