### PR TITLE
Fix docs_sphinx 'make html' error

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,4 +104,3 @@ Batavia is part of the `BeeWare suite`_. You can talk to the community through:
    how-to/index
    reference/index
    background/index
-   project/index

--- a/docs/tutorial/tutorial-2.rst
+++ b/docs/tutorial/tutorial-2.rst
@@ -19,7 +19,7 @@ You can alternatively directly run the ``run_in_batavia.js`` in Node. If
 you are not in the Batavia project directory you can still use this script as
 follows:
 
-.. code-bloc:: bash
+.. code-block:: bash
 
     node /path/to/batavia/run_in_batavia.js /path/to/python_file.py
 


### PR DESCRIPTION
docs sphinx 'make html' error

<img width="1144" alt="2017-11-21 7 00 17" src="https://user-images.githubusercontent.com/18658656/33066906-e8335b4a-ceef-11e7-9d68-5200c2038bb0.png">

1. delete 'project/index'(line 107) in 'index.rst'

and next error

<img width="1144" alt="2017-11-21 7 00 37" src="https://user-images.githubusercontent.com/18658656/33067024-3f0a410e-cef0-11e7-82ec-05052a192a95.png">

2. modified 'docs/tutorial/tutorial-2.rst'
line22 'code-bloc' -> 'code-block'

finally,
<img width="1144" alt="2017-11-21 7 01 36" src="https://user-images.githubusercontent.com/18658656/33067214-cf369cbe-cef0-11e7-9acd-10a3cda753f2.png">

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
#686 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
