### PR TITLE
Console scroll bar stays bottom when exceeds maximum height

### DIFF
--- a/testserver/testbed.html
+++ b/testserver/testbed.html
@@ -128,6 +128,9 @@ PyConsole.prototype.write = function(buffer) {
     var text = document.createTextNode(buffer);
     this.element.appendChild(text);
 
+    // Console scrollbar stays bottom.
+    this.element.scrollTop = this.element.scrollHeight;
+
     // Also echo to the console.
     console.log(buffer)
 }


### PR DESCRIPTION
**------------------------------- Describe your changes in detail -----------------------------------**
Added the code (`this.element.scrollTop = this.element.scrollHeight`) for the scrollbar to stay bottom when the console output results exceed the console box's maximum height.

**----------------------------- What problem does this change solve? -----------------------------**
As it is mentioned in issue #698 , Scrollbar of console output just stayed top even though the results' height is longer than the console box maximum height.
Now it focuses bottom(last result) when the results exceed box's maximum height just like any other code editors' console.

**------------------------------------------- Fixed issue -------------------------------------------**
It Fixes #698 .

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct