### PR TITLE
Fixed implementation Float.__floordiv__ for Int

### DIFF
--- a/batavia/types/Float.js
+++ b/batavia/types/Float.js
@@ -316,7 +316,7 @@ Float.prototype.__floordiv__ = function(other) {
 
     if (types.isinstance(other, types.Int)) {
         if (!other.val.isZero()) {
-            return new Float(Math.floor(this.valueOf() / other.valueOf()))
+            return new Float(Math.floor(this.valueOf() / other.__float__().valueOf()))
         } else {
             throw new exceptions.ZeroDivisionError.$pyclass('float divmod()')
         }

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -41,8 +41,6 @@ class BinaryFloatOperationTests(BinaryOperationTestCase, TranspileTestCase):
 
         # these work, but print incorrectly
 
-        'test_floor_divide_int',
-
         'test_true_divide_int',
 
 

--- a/tests/datatypes/test_float.py
+++ b/tests/datatypes/test_float.py
@@ -88,8 +88,6 @@ class InplaceFloatOperationTests(InplaceOperationTestCase, TranspileTestCase):
 
         # these work, but print incorrectly
 
-        'test_floor_divide_int',
-
         'test_true_divide_int',
 
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Fixed the implementation for Float.__floordiv__  for division of it by integer datatype by changing the "other.valueOf()" by "other.__float__().valueOf()" as initially float datatype was directly getting divided by integer datatype according to javascript standards but now after making changes the float datatype will get divided by integer datatype according to python standards.

<!--- What problem does this change solve? -->
 Now the test_floor_divide_int for float datatype is passing which was initially marked as expected failure.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Refs #46 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
