### PR TITLE
A few more small fixes around strings and floats

### DIFF
--- a/batavia/builtins/float.js
+++ b/batavia/builtins/float.js
@@ -15,7 +15,7 @@ function float(args, kwargs) {
     if (types.isinstance(value, types.Str)) {
         if (value.length === 0) {
             throw new exceptions.ValueError.$pyclass('could not convert string to float: ')
-        } else if (value.search(/[^0-9.]/g) === -1) {
+        } else if (value.search(/[^-0-9.]/g) === -1) {
             return new types.Float(parseFloat(value))
         } else {
             if (value === 'nan' || value === '+nan' || value === '-nan') {

--- a/batavia/builtins/repr.js
+++ b/batavia/builtins/repr.js
@@ -13,6 +13,8 @@ function repr(args, kwargs) {
 
     if (args[0] === null) {
         return 'None'
+    } else if (args[0].__repr__ && args[0].__repr__.__call__) {
+        return args[0].__repr__.__call__([args[0]])
     } else if (args[0].__repr__) {
         return args[0].__repr__()
     } else {

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -269,12 +269,20 @@ Str.prototype.__ge__ = function(other) {
     }
 }
 
+// ********************************************************************************************
+// By Mozilla Contributors under CC-BY-SA v2.5 or later
+// From MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+var escapeRegExp = function(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+}
+// ********************************************************************************************
+
 Str.prototype.__contains__ = function(other) {
     var types = require('../types')
     if (!types.isinstance(other, [types.Str])) {
         throw new exceptions.TypeError.$pyclass("'in <string>' requires string as left operand, not " + type_name(other))
     } else {
-        return this.valueOf().search(other.valueOf()) >= 0
+        return this.valueOf().search(escapeRegExp(other.valueOf())) >= 0
     }
 }
 

--- a/batavia/types/Str.js
+++ b/batavia/types/Str.js
@@ -587,9 +587,9 @@ Str.prototype.__len__ = function() {
     return new types.Int(this.length)
 }
 
-Str.prototype.index = function(needle) {
+Str.prototype.index = function(needle, offset) {
     var types = require('../types')
-    var i = this.indexOf(needle)
+    var i = this.indexOf(needle, offset)
     if (i < 0) {
         throw new exceptions.ValueError.$pyclass('substring not found')
     }

--- a/tests/builtins/test_float.py
+++ b/tests/builtins/test_float.py
@@ -2,7 +2,10 @@ from .. utils import TranspileTestCase, BuiltinFunctionTestCase
 
 
 class FloatTests(TranspileTestCase):
-    pass
+    def test_can_parse_negative_1(self):
+        self.assertCodeExecution("""
+            print(float("-1"))
+            """)
 
 
 class BuiltinFloatFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_repr.py
+++ b/tests/builtins/test_repr.py
@@ -12,6 +12,14 @@ class ReprTests(TranspileTestCase):
             print(repr("".join(chr(x) for x in range(128))))
             """)
 
+    def test_repr_custom_class(self):
+        self.assertCodeExecution("""
+            class A:
+                def __repr__(self):
+                    return "Mÿ hôvèrçràft îß fûłl öf éêlś"
+            print(repr(A()))
+            """)
+
 
 class BuiltinReprFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "repr"

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -689,11 +689,13 @@ class StrTests(TranspileTestCase):
 
     def test_index(self):
         self.assertCodeExecution("""
-        print("abc".index("d"))
+        print("abca".index("a", 0))
+        print("abca".index("a", 1))
         print("abc".index("a"))
         print("abc".index("b"))
         print("abc".index("c"))
         print("abc".index("bc"))
+        print("abc".index("d"))
         """)
 
 class FormatTests(TranspileTestCase):

--- a/tests/datatypes/test_str.py
+++ b/tests/datatypes/test_str.py
@@ -698,6 +698,11 @@ class StrTests(TranspileTestCase):
         print("abc".index("d"))
         """)
 
+    def test_contains_escapes_regular_expressions(self):
+        self.assertCodeExecution("""
+        print('(' not in '(/)')
+        """)
+
 class FormatTests(TranspileTestCase):
         alternate = ('#', '')
 


### PR DESCRIPTION
* `repr()` should call Python methods with `__call__`
* `str.index` supports 2 arguments
* `float()` should support parsing negative numbers
* Escape regular expressions when using Javascript `.search`

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
