### PR TITLE
Account for -0 when doing int ops

### DIFF
--- a/batavia/builtins/oct.js
+++ b/batavia/builtins/oct.js
@@ -9,7 +9,7 @@ function oct(args, kwargs) {
     }
     var value = args[0]
     if (types.isinstance(value, types.Int)) {
-        if (value.val.isNeg()) {
+        if (value.val.isNeg() && !value.val.isZero()) {
             return '-0o' + value.val.toString(8).substr(1)
         } else {
             return '0o' + value.val.toString(8)

--- a/tests/datatypes/test_int.py
+++ b/tests/datatypes/test_int.py
@@ -53,6 +53,11 @@ class IntTests(TranspileTestCase):
             print((2**1024)+1)
             """)
 
+    def test_comparisons_behave(self):
+        self.assertCodeExecution("""
+            print(((1 == 2) * -1) & ((1 == 2) * -1))
+        """)
+
 
 class UnaryIntOperationTests(UnaryOperationTestCase, TranspileTestCase):
     data_type = 'int'


### PR DESCRIPTION
The bignumber library allows `-0`, which causes lots of weird things to happen that should not happen.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
