### PR TITLE
Fix issue #733 - pow not working properly for corner cases

### DIFF
--- a/batavia/builtins/pow.js
+++ b/batavia/builtins/pow.js
@@ -23,11 +23,15 @@ function pow(args, kwargs) {
         if (y < 0) {
             throw new exceptions.TypeError.$pyclass('pow() 2nd argument cannot be negative when 3rd argument specified')
         }
-        if (y === 0) {
-            return 1
-        }
-        if (z === 1) {
+
+        // if z is 1 or -1 then answer is always 0
+        if (parseInt(z) === 1 || parseInt(z) === -1) {
             return 0
+        }
+
+        // if y is 0 provided z is not 1 or -1, then answer is always 1
+        if (parseInt(y) == 0) {
+            return 1
         }
 
         // right-to-left exponentiation to reduce memory and time

--- a/tests/builtins/test_pow.py
+++ b/tests/builtins/test_pow.py
@@ -28,6 +28,22 @@ class PowTests(TranspileTestCase):
             print(pow(x, y, z))
         """)
 
+    def test_int_y_zero_z_one(self):
+        self.assertCodeExecution("""
+            x = 1
+            y = 0
+            z = 1
+            print(pow(x, y, z))
+        """)
+
+    def test_int_y_zero_z_neg_one(self):
+        self.assertCodeExecution("""
+            x = 1
+            y = 0
+            z = -1
+            print(pow(x, y, z))
+        """)
+
     def test_float_x_with_z(self):
         self.assertCodeExecution("""
             x = 3.3


### PR DESCRIPTION
Fixed issue #733. Pow function is now working properly
for the case when y=0 and z=1 or -1. Corresponding tests
have also been added.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
