### PR TITLE
Remove trailing whitespaces from Batavia

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,4 +6,4 @@ If a member of the BeeWare community has made you feel uncomfortable, we have me
 
 Changes to our behaviour documentation [are also documented](https://pybee.org/community/behavior/changes/)
 
-See the [Community Behaviour](https://pybee.org/community/behavior/) section of the PyBee.org website for more information. 
+See the [Community Behaviour](https://pybee.org/community/behavior/) section of the PyBee.org website for more information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing
 
-PyBee <3's contributions! 
+PyBee <3's contributions!
 
-Please be aware, PyBee operates under a Code of Conduct. 
+Please be aware, PyBee operates under a Code of Conduct.
 
 See [CONTRIBUTING to PyBee](http://pybee.org/contributing) for details.
 

--- a/docs/tutorial/tutorial-0.rst
+++ b/docs/tutorial/tutorial-0.rst
@@ -22,18 +22,18 @@ how to set this up are `on our Environment setup guide
 .. tabs::
 
     .. group-tab:: Linux
-    
+
         .. code-block:: bash
-        
+
            $ python3.5 -m venv venv
            $ . venv/bin/activate
            $ cd batavia
            $ pip install -e .
-           
+
     .. group-tab:: MacOS
-    
+
         .. code-block:: bash
-        
+
            $ python3.5 -m venv venv
            $ . venv/bin/activate
            $ cd batavia

--- a/run_in_batavia.js
+++ b/run_in_batavia.js
@@ -19,7 +19,7 @@ Runs Python file in node JS using using the Batavia virtual machine in Node.
 
 positional arguments:
   file             Python file to run
-  
+
 optional arguments:
   -h, --help       show this help message and exit`.trim())
 }

--- a/tests/structures/test_datamodel.py
+++ b/tests/structures/test_datamodel.py
@@ -21,7 +21,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p2 = Pair(9, 4)
 
-            print(p1 + p2)    
+            print(p1 + p2)
         """, run_in_function=False)
 
     def test_subtract(self):
@@ -42,7 +42,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p2 = Pair(9, 4)
 
-            print(p1 - p2)    
+            print(p1 - p2)
         """, run_in_function=False)
 
     def test_multiply(self):
@@ -63,7 +63,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 * num)    
+            print(p1 * num)
         """, run_in_function=False)
 
     def test_truedivision(self):
@@ -84,7 +84,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 / num)    
+            print(p1 / num)
         """, run_in_function=False)
 
     def test_floordivision(self):
@@ -105,7 +105,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 // num)    
+            print(p1 // num)
         """, run_in_function=False)
 
     def test_mod(self):
@@ -126,7 +126,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 % num)    
+            print(p1 % num)
         """, run_in_function=False)
 
     def test_pow(self):
@@ -147,7 +147,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 ** num)    
+            print(p1 ** num)
         """, run_in_function=False)
 
     def test_lshift(self):
@@ -168,7 +168,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 << num)    
+            print(p1 << num)
         """, run_in_function=False)
 
     def test_rshift(self):
@@ -189,7 +189,7 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             num = 4
 
-            print(p1 >> num)    
+            print(p1 >> num)
         """, run_in_function=False)
 
     def test_and(self):
@@ -209,8 +209,8 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p2 = Pair(6, 5)
-            
-            print(p1 & p2)    
+
+            print(p1 & p2)
         """, run_in_function=False)
 
     def test_xor(self):
@@ -230,8 +230,8 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p2 = Pair(6, 5)
-            
-            print(p1 ^ p2)    
+
+            print(p1 ^ p2)
         """, run_in_function=False)
 
     def test_or(self):
@@ -251,8 +251,8 @@ class ClassBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p2 = Pair(6, 5)
-            
-            print(p1 | p2)    
+
+            print(p1 | p2)
         """, run_in_function=False)
 
 
@@ -275,7 +275,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 += Pair(9, 4)
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_isubtract(self):
@@ -296,7 +296,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 -= Pair(9, 4)
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_imultiply(self):
@@ -316,8 +316,8 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p1 *= 4
-            
-            print(p1)    
+
+            print(p1)
         """, run_in_function=False)
 
     def test_itruedivision(self):
@@ -338,7 +338,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 /=4
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_ifloordivision(self):
@@ -359,7 +359,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 //= 4
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_imod(self):
@@ -380,7 +380,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 %= 4
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_ipow(self):
@@ -401,7 +401,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 **= 4
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_ilshift(self):
@@ -422,7 +422,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 <<= 2
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_irshift(self):
@@ -443,7 +443,7 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
             p1 = Pair(5, 6)
             p1 >>= 2
 
-            print(p1)    
+            print(p1)
         """, run_in_function=False)
 
     def test_iand(self):
@@ -463,8 +463,8 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p1 &= Pair(6, 5)
-            
-            print(p1)    
+
+            print(p1)
         """, run_in_function=False)
 
     def test_ixor(self):
@@ -484,8 +484,8 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p1 ^= Pair(6, 5)
-            
-            print(p1)    
+
+            print(p1)
         """, run_in_function=False)
 
     def test_ior(self):
@@ -505,8 +505,8 @@ class ClassInPlaceOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
             p2 |= Pair(6, 5)
-            
-            print(p1)    
+
+            print(p1)
         """, run_in_function=False)
 
 @expectedFailure
@@ -517,17 +517,17 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
                 def __init__(self, x, y):
                     self.x = x
                     self.y = y
-            
+
                 def __str__(self):
                     return "({}, {})".format(self.x, self.y)
-            
+
                 def __radd__(self, other):
                     x = self.x + other
                     y = self.y + other
                     return Pair(x, y)
-            
+
             p1 = Pair(5, 6)
-            
+
             print(4 + p1)
         """, run_in_function=False)
 
@@ -537,17 +537,17 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
                 def __init__(self, x, y):
                     self.x = x
                     self.y = y
-            
+
                 def __str__(self):
                     return "({}, {})".format(self.x, self.y)
-            
+
                 def __rsub__(self, other):
-                    x = other - self.x 
-                    y = other - self.y 
+                    x = other - self.x
+                    y = other - self.y
                     return Pair(x, y)
-            
+
             p1 = Pair(5, 6)
-            
+
             print(4 - p1)
         """, run_in_function=False)
 
@@ -568,7 +568,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(3 * p1)    
+            print(3 * p1)
         """, run_in_function=False)
 
     def test_rtruedivision(self):
@@ -583,12 +583,12 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
                 def __rtruediv__(self, other):
                     x = other / self.x
-                    y = other / self.y 
+                    y = other / self.y
                     return Pair(x, y)
 
             p1 = Pair(5, 6)
 
-            print(4 / p1)    
+            print(4 / p1)
         """, run_in_function=False)
 
     def test_rfloordivision(self):
@@ -602,13 +602,13 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
                     return "({}, {})".format(self.x, self.y)
 
                 def __rfloordiv__(self, other):
-                    x = other // self.x 
+                    x = other // self.x
                     y = other // self.y
                     return Pair(x, y)
 
             p1 = Pair(5, 6)
 
-            print(4 // p1)    
+            print(4 // p1)
         """, run_in_function=False)
 
     def test_rmod(self):
@@ -622,13 +622,13 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
                     return "({}, {})".format(self.x, self.y)
 
                 def __rmod__(self, other):
-                    x = other % self.x 
-                    y = other % self.y 
+                    x = other % self.x
+                    y = other % self.y
                     return Pair(x, y)
 
             p1 = Pair(5, 6)
 
-            print(4 % p1)    
+            print(4 % p1)
         """, run_in_function=False)
 
     def test_rpow(self):
@@ -648,7 +648,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 ** p1)    
+            print(4 ** p1)
         """, run_in_function=False)
 
     def test_rlshift(self):
@@ -668,7 +668,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 << p1)    
+            print(4 << p1)
         """, run_in_function=False)
 
     def test_rrshift(self):
@@ -688,7 +688,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 >> p1)    
+            print(4 >> p1)
         """, run_in_function=False)
 
     def test_rand(self):
@@ -708,7 +708,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 & p1)    
+            print(4 & p1)
         """, run_in_function=False)
 
     def test_rxor(self):
@@ -728,7 +728,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 ^ p1)    
+            print(4 ^ p1)
         """, run_in_function=False)
 
     def test_ror(self):
@@ -748,7 +748,7 @@ class ClassReverseBinaryOpsDataModelTests(TranspileTestCase):
 
             p1 = Pair(5, 6)
 
-            print(4 | p1) 
+            print(4 | p1)
         """, run_in_function=False)
 
 
@@ -771,7 +771,7 @@ class ClassContainerDataModelTests(TranspileTestCase):
                     raise IndexError
 
             p = Pair(5, 6)
-            
+
             print('p[0] =', p[0])
             print('p[0] =', p[1])
             print('p["x"] =', p['x'])
@@ -799,10 +799,10 @@ class ClassContainerDataModelTests(TranspileTestCase):
                         raise IndexError
 
             p = Pair(5, 6)
-            
+
             print(p)
             p[1] = 11
             print(p)
             p['x'] = 2
-            print(p)            
+            print(p)
         """, run_in_function=False)

--- a/testserver/manage.py
+++ b/testserver/manage.py
@@ -3,11 +3,11 @@ import os
 import sys
 
 if __name__ == "__main__":
-    
+
     if sys.version_info[0] != 3:
         sys.stderr.write('Batavia requires Python 3' + os.linesep)
         sys.exit(1)
-    
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
     from django.core.management import execute_from_command_line

--- a/testserver/sample.py
+++ b/testserver/sample.py
@@ -34,7 +34,7 @@ def try_builtins():
     print('divmod(5,2)', divmod(5, 2))
     print('pow(2, 3)', pow(2, 3))
     print('pow(2, 3, 3)', pow(2, 3, 3))
-    
+
     try:
         print('abs(None)', abs(None))  # known failure
     except TypeError:

--- a/testserver/styles/cutive/OFL.txt
+++ b/testserver/styles/cutive/OFL.txt
@@ -17,7 +17,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/testserver/testbed.html
+++ b/testserver/testbed.html
@@ -37,8 +37,8 @@
          The file encoded is the entire test.pystone module. The naming
          of the ID is significant - it's a naming convention that
          allows the Python `import` statement to find other modules. -->
-    <script 
-        id="batavia-test.pystone" 
+    <script
+        id="batavia-test.pystone"
         type="application/python-bytecode"
         data-filename="{{ modules.pystone.filename }}">
 {{ modules.pystone.compiled }}

--- a/testserver/urls.py
+++ b/testserver/urls.py
@@ -28,7 +28,7 @@ def bytecode(sourcefile):
         'compiled': payload,
         'filename': sourcefile
     }
-    
+
 def home(request):
     ctx = {
         'modules': {
@@ -50,7 +50,7 @@ def home(request):
                 }
             }
         }
-    } 
+    }
     if request.method.lower() == 'post' and request.POST['code']:
         tempfd, tempname = tempfile.mkstemp()
         with os.fdopen(tempfd, 'w+b') as f:


### PR DESCRIPTION
Removed trailing whitespaces from Batavia using `git grep -I --name-only -z -e '' | xargs -0 sed -i 's/[ \t]\+\(\r\?\)$/\1/'` :smile:

## PR Checklist:
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
