### PR TITLE
Added Error Catching for Unsupported Types to Builtin int()

### DIFF
--- a/batavia/builtins/int.js
+++ b/batavia/builtins/int.js
@@ -1,5 +1,6 @@
 var exceptions = require('../core').exceptions
 var types = require('../types')
+var type_name = require('../core').type_name
 var repr = require('./repr')
 
 function int(args, kwargs) {
@@ -12,12 +13,23 @@ function int(args, kwargs) {
 
     var base = 10
     var value = 0
+    var unsupported_numeric_types = [types.Complex]
+    var unsupported_nonnumeric_types = [types.Dict, types.FrozenSet, types.List, types.NoneType,
+        types.NotImplementedType, types.Range, types.Set, types.Slice, types.Tuple]
     if (!args || args.length === 0) {
         return new types.Int(0)
     } else if (args && args.length === 1) {
         value = args[0]
         if (types.isinstance(value, [types.Int, types.Bool])) {
             return value.__int__()
+        } else if (types.isinstance(value, unsupported_numeric_types)) {
+            throw new exceptions.TypeError.$pyclass(
+                "can't convert " + type_name(value) + ' to int'
+            )
+        } else if (types.isinstance(value, unsupported_nonnumeric_types)) {
+            throw new exceptions.TypeError.$pyclass(
+                "int() argument must be a string, a bytes-like object or a number, not '" + type_name(value) + "'"
+            )
         }
     } else if (args && args.length === 2) {
         value = args[0]

--- a/tests/builtins/test_int.py
+++ b/tests/builtins/test_int.py
@@ -16,14 +16,4 @@ class BuiltinIntFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     not_implemented = [
         'test_bytearray',
         'test_class',
-        'test_complex',
-        'test_dict',
-        'test_frozenset',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_tuple',
     ]

--- a/tests/builtins/test_int.py
+++ b/tests/builtins/test_int.py
@@ -12,8 +12,3 @@ class IntTests(TranspileTestCase):
 
 class BuiltinIntFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "int"
-
-    not_implemented = [
-        'test_bytearray',
-        'test_class',
-    ]


### PR DESCRIPTION
<!--- Describe your changes in detail -->
### Details:
Add python-compliant TypeError handling for complex, dict, frozenset, list, None, NotImplemented, range, set, slice, and tuple. Later commit added handling for classes and bytearrays.
<!--- What problem does this change solve? -->
### Problem:
The implementation of int() did not correctly catch errors related to the passing of unsupported types.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
### Fixes:
Contributes to fixing #47 [Finish implementation of builtins].

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
