### PR TITLE
Completed implementation of float() builtin - all test cases now passing.

### DIFF
--- a/batavia/builtins/float.js
+++ b/batavia/builtins/float.js
@@ -3,7 +3,6 @@ var str = require('./str')
 var type_name = require('../core').type_name
 var types = require('../types')
 
-
 function float(args, kwargs) {
     if (args.length > 1) {
         throw new exceptions.TypeError.$pyclass('float() takes at most 1 argument (' + args.length + ' given)')

--- a/batavia/builtins/float.js
+++ b/batavia/builtins/float.js
@@ -1,6 +1,8 @@
 var exceptions = require('../core').exceptions
+var str = require('./str')
 var type_name = require('../core').type_name
 var types = require('../types')
+
 
 function float(args, kwargs) {
     if (args.length > 1) {
@@ -12,8 +14,19 @@ function float(args, kwargs) {
 
     var value = args[0]
 
-    if (types.isinstance(value, types.Str)) {
-        if (value.length === 0) {
+    // For some reason complex throws a non-standard error message
+    if (types.isinstance(value, types.Complex)) {
+        throw new exceptions.TypeError.$pyclass("can't convert complex to float")
+    }
+
+    if (types.isinstance(value, [types.Bytes, types.Bytearray, types.Str])) {
+        // Attempt to convert bytearray to string for parsing.
+        var was_byte_object = false
+        if (types.isinstance(value, [types.Bytes, types.Bytearray])) {
+            was_byte_object = true
+            value = str([value], null)
+        }
+        if (value.length === 0 || value === "b''" || value === "bytearray''") {
             throw new exceptions.ValueError.$pyclass('could not convert string to float: ')
         } else if (value.search(/[^-0-9.]/g) === -1) {
             return new types.Float(parseFloat(value))
@@ -25,7 +38,12 @@ function float(args, kwargs) {
             } else if (value === '-inf') {
                 return new types.Float(-Infinity)
             }
-            throw new exceptions.ValueError.$pyclass("could not convert string to float: '" + args[0] + "'")
+            // Byte object errors are reported without quotations.
+            if (was_byte_object) {
+                throw new exceptions.ValueError.$pyclass('could not convert string to float: ' + value)
+            } else {
+                throw new exceptions.ValueError.$pyclass("could not convert string to float: '" + value + "'")
+            }
         }
     } else if (types.isinstance(value, [types.Int, types.Bool, types.Float])) {
         return args[0].__float__()

--- a/tests/builtins/test_float.py
+++ b/tests/builtins/test_float.py
@@ -10,9 +10,3 @@ class FloatTests(TranspileTestCase):
 
 class BuiltinFloatFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "float"
-
-    not_implemented = [
-        'test_bytearray',
-        'test_bytes',
-        'test_complex',
-    ]


### PR DESCRIPTION
<!--- Describe your changes in detail -->
### Changes
Added python-compliant error handling support for passing complex, byte and bytearray objects to the float builtin function. Some of these types threw non-standard messages in python and this functionality has been implemented in Batavia.
<!--- What problem does this change solve? -->
### Problem
Error handling for objects of type complex, bytes and bytearray when passed to the builtin float() did not conform to the CPython implementation (generally threw ValueErrors instead of the correct TypeErrors). These issues were the causes of all remaining test failures in the float() Batavia implementation.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
### Issues
Contributes to fixing #47.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
