### PR TITLE
fixed implementation of hex() builtin - all tests pass

### DIFF
--- a/batavia/builtins/hex.js
+++ b/batavia/builtins/hex.js
@@ -1,11 +1,32 @@
+var BigNumber = require('bignumber.js')
 var exceptions = require('../core').exceptions
+var type_name = require('../core').type_name
+var types = require('../types')
 
 function hex(args, kwargs) {
     if (args.length !== 1) {
         throw new exceptions.TypeError.$pyclass('hex() takes exactly one argument (' + args.length + ' given)')
-    };
-    var int = args[0].val
-    return '0x' + int.toString(16)
+    }
+    let value = args[0]
+    let supported_types = [types.Bool, types.Int]
+    let unsupported_types = [types.Bytearray, types.Bytes, types.Complex, types.Dict, types.Float, types.FrozenSet,
+        types.List, types.NoneType, types.NotImplementedType, types.Range, types.Set, types.Slice, types.Str,
+        types.Tuple]
+    if (types.isinstance(value, supported_types)) {
+        value = value.__int__()
+    // Check for unsupported types and classes (type_name = 'type' when arg is a class)
+    } else if (types.isinstance(value, unsupported_types) || type_name(value) === 'type') {
+        throw new exceptions.TypeError.$pyclass("'" + type_name(value) + "' object cannot be interpreted as an integer")
+    }
+    // Javascript does not have native support for intergers as large as those supported by Python (uses Infinity)
+    value = new BigNumber(value)
+    // Javascript represents negative hex differently (e.g. -5 == (JS: 0x-5 || Py: -0x5))
+    if (value < 0) {
+        value = value.negated()
+        return '-0x' + value.toString(16)
+    } else {
+        return '0x' + value.toString(16)
+    }
 }
 hex.__doc__ = "hex(number) -> string\n\nReturn the hexadecimal representation of an integer.\n\n   >>> hex(3735928559)\n   '0xdeadbeef'\n"
 

--- a/tests/builtins/test_hex.py
+++ b/tests/builtins/test_hex.py
@@ -12,23 +12,3 @@ class HexTests(TranspileTestCase):
 
 class BuiltinHexFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "hex"
-
-    not_implemented = [
-        'test_bool',
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_int',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
-    ]


### PR DESCRIPTION
<!--- Describe your changes in detail -->
### Changes
Completed the implementation of hex for all input types. Had to introduce a dependency to the implementation (BigNumber - previously used in the implementation of the Integer type) due to the differences in how Python and Javascript handle large numbers. Unsupported types are now handled with Python-compliant errors.
<!--- What problem does this change solve? -->
### Problem
The builtin function hex was failing for input from every builtin type, including Bool and Int, which it is supposed to support. Other types were failing with incorrect error types.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
### Fixes
Contributes to fixing #47 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
