### PR TITLE
Fixed oct() builtin error handling - all test cases now pass

### DIFF
--- a/batavia/builtins/oct.js
+++ b/batavia/builtins/oct.js
@@ -1,4 +1,5 @@
 var exceptions = require('../core').exceptions
+var type_name = require('../core').type_name
 var types = require('../types')
 
 function oct(args, kwargs) {
@@ -16,20 +17,9 @@ function oct(args, kwargs) {
         }
     } else if (types.isinstance(value, types.Bool)) {
         return '0o' + value.__int__().toString(8)
+    } else {
+        throw new exceptions.TypeError.$pyclass("'" + type_name(value) + "' object cannot be interpreted as an integer")
     }
-
-    if (!types.isinstance(value, types.Int)) {
-        if (value.__index__) {
-            value = value.__index__()
-        } else {
-            throw new exceptions.TypeError.$pyclass('__index__ method needed for non-integer inputs')
-        }
-    }
-    if (value < 0) {
-        return '-0o' + (0 - value).toString(8)
-    }
-
-    return '0o' + value.toString(8)
 };
 oct.__doc__ = "oct(number) -> string\n\nReturn the octal representation of an integer.\n\n   >>> oct(342391)\n   '0o1234567'\n"
 

--- a/tests/builtins/test_oct.py
+++ b/tests/builtins/test_oct.py
@@ -7,21 +7,3 @@ class OctTests(TranspileTestCase):
 
 class BuiltinOctFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):
     function = "oct"
-
-    not_implemented = [
-        'test_bytearray',
-        'test_bytes',
-        'test_class',
-        'test_complex',
-        'test_dict',
-        'test_float',
-        'test_frozenset',
-        'test_list',
-        'test_None',
-        'test_NotImplemented',
-        'test_range',
-        'test_set',
-        'test_slice',
-        'test_str',
-        'test_tuple',
-    ]


### PR DESCRIPTION
<!--- Describe your changes in detail -->
### Changes
Added correct TypeError reporting for incorrect use of oct() builtin. All incorrect argument types now throw TypeErrors with python-compliant error messages.

<!--- What problem does this change solve? -->
### Problem
Error handling for unsupported types passed to the builtin oct() method was not python-compliant.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
### Fixes
Contributes to fixing #47 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
