### PR TITLE
 Fix testserver [Errno 2] No such file or directory errors

### DIFF
--- a/testserver/requirements.txt
+++ b/testserver/requirements.txt
@@ -1,2 +1,2 @@
-django==1.10
+django==1.11.18
 pytz

--- a/testserver/urls.py
+++ b/testserver/urls.py
@@ -29,24 +29,25 @@ def bytecode(sourcefile):
         'filename': sourcefile
     }
 
+
 def home(request):
     ctx = {
         'modules': {
-            'sample': bytecode('sample.py'),
-            'other': bytecode('other.py'),
+            'sample': bytecode('testserver/sample.py'),
+            'other': bytecode('testserver/other.py'),
             'pystone': bytecode(pystone.__file__),
             'submodule': {
-                'init': bytecode('submodule/__init__.py'),
-                'modulea': bytecode('submodule/modulea.py'),
-                'moduleb': bytecode('submodule/moduleb.py'),
-                'modulec': bytecode('submodule/modulec.py'),
+                'init': bytecode('testserver/submodule/__init__.py'),
+                'modulea': bytecode('testserver/submodule/modulea.py'),
+                'moduleb': bytecode('testserver/submodule/moduleb.py'),
+                'modulec': bytecode('testserver/submodule/modulec.py'),
                 'moduled': {
-                    'init': bytecode('submodule/moduled/__init__.py'),
-                    'submoduled': bytecode('submodule/moduled/submoduled.py'),
+                    'init': bytecode('testserver/submodule/moduled/__init__.py'),
+                    'submoduled': bytecode('testserver/submodule/moduled/submoduled.py'),
                 },
                 'subsubmodule': {
-                    'init': bytecode('submodule/subsubmodule/__init__.py'),
-                    'submodulea': bytecode('submodule/subsubmodule/submodulea.py'),
+                    'init': bytecode('testserver/submodule/subsubmodule/__init__.py'),
+                    'submodulea': bytecode('testserver/submodule/subsubmodule/submodulea.py'),
                 }
             }
         }


### PR DESCRIPTION
Previously when using the Batavia testbed, I was getting no such file or directory errors and the "run sample.py" button wasn't working.

```
[20/Jan/2019` 02:57:39] "GET / HTTP/1.1" 200 16945
[Errno 2] No such file or directory: 'sample.py'
[Errno 2] No such file or directory: 'other.py'
[Errno 2] No such file or directory: 'submodule/__init__.py'
[Errno 2] No such file or directory: 'submodule/modulea.py'
[Errno 2] No such file or directory: 'submodule/moduleb.py'
[Errno 2] No such file or directory: 'submodule/modulec.py'
[Errno 2] No such file or directory: 'submodule/moduled/__init__.py'
[Errno 2] No such file or directory: 'submodule/moduled/submoduled.py'
[Errno 2] No such file or directory: 'submodule/subsubmodule/__init__.py'
[Errno 2] No such file or directory: 'submodule/subsubmodule/submodulea.py'
```
This change corrects the error by changing the filename in the context dictionary of the urls module to prepend testserver to the path.

This change also adds on to #768 by updating the django version that the test server uses to the latest LTR version to fix security vulnerabilities.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct