### PR TITLE
Update list implementation.

### DIFF
--- a/batavia/builtins/list.js
+++ b/batavia/builtins/list.js
@@ -7,14 +7,17 @@ list.__call__ = function(args, kwargs) {
     if (arguments.length !== 2) {
         throw new builtins.BataviaError.$pyclass("Batavia calling convention not used.");
     }
-
-    if (kwargs && Object.keys(kwargs).length) {
-        if (Object.keys(kwargs).length + args.length > 1) {
-            throw new exceptions.TypeError.$pyclass('list() takes at most 1 argument (' + (args.length + Object.keys(kwargs).length) + ' given)')
-        } else {
-            throw new exceptions.TypeError.$pyclass("'" + Object.keys(kwargs)[0] + "' is an invalid keyword argument for this function")
-        }
+    
+    // Accept exactly one argument & account for undefined
+    if (args.length > 1 || Object.keys(kwargs).length + args.length > 1) {
+        throw new exceptions.TypeError.$pyclass('list() takes at most 1 argument (' + (args.length + Object.keys(kwargs).length) + ' given)')
     }
+
+    // No kwargs
+    if (kwargs && Object.keys(kwargs).length) {
+        throw new exceptions.TypeError.$pyclass("'" + Object.keys(kwargs)[0] + "' is an invalid keyword argument for this function")
+    }
+
     if (!args || args.length === 0) {
         return new types.List()
     }

--- a/batavia/builtins/list.js
+++ b/batavia/builtins/list.js
@@ -1,11 +1,21 @@
 var types = require('../types')
+var exceptions = require('../core/exceptions')
 
 var list = types.List.prototype.__class__
 
-list.__call__ = function(args) {
+list.__call__ = function(args, kwargs) {
+    // Reject kwargs
+    if (kwargs && Object.keys(kwargs).length) {
+        if (Object.keys(kwargs).length + args.length > 1) {
+            throw new exceptions.TypeError.$pyclass('list() takes at most 1 argument (' + (args.length + Object.keys(kwargs).length) + ' given)')
+        } else {
+            throw new exceptions.TypeError.$pyclass("'" + (args.length + Object.keys(kwargs)[0]) + "' is an invalid keyword argument for this function")
+        }
+    }
     if (!args || args.length === 0) {
         return new types.List()
     }
+    
     return new types.List(args[0])
 }
 list.__doc__ = "list() -> new empty list\nlist(iterable) -> new list initialized from iterable's items"

--- a/batavia/builtins/list.js
+++ b/batavia/builtins/list.js
@@ -4,12 +4,15 @@ var exceptions = require('../core/exceptions')
 var list = types.List.prototype.__class__
 
 list.__call__ = function(args, kwargs) {
-    // Reject kwargs
+    if (arguments.length !== 2) {
+        throw new builtins.BataviaError.$pyclass("Batavia calling convention not used.");
+    }
+
     if (kwargs && Object.keys(kwargs).length) {
         if (Object.keys(kwargs).length + args.length > 1) {
             throw new exceptions.TypeError.$pyclass('list() takes at most 1 argument (' + (args.length + Object.keys(kwargs).length) + ' given)')
         } else {
-            throw new exceptions.TypeError.$pyclass("'" + (args.length + Object.keys(kwargs)[0]) + "' is an invalid keyword argument for this function")
+            throw new exceptions.TypeError.$pyclass("'" + Object.keys(kwargs)[0] + "' is an invalid keyword argument for this function")
         }
     }
     if (!args || args.length === 0) {

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -717,7 +717,7 @@ List.prototype.index = function(value, start, stop) {
             return i
         }
     }
-    throw new exceptions.ValueError.$pyclass('list.index(x): x not in list')
+    throw new exceptions.ValueError.$pyclass(value.toString() + ' is not in list')
 }
 
 List.prototype.reverse = function() {
@@ -725,6 +725,27 @@ List.prototype.reverse = function() {
         throw new exceptions.TypeError.$pyclass('reverse() takes no arguments (' + arguments.length + ' given)')
     }
     Array.prototype.reverse.apply(this)
+}
+
+List.prototype.sort = function(key=None, reverse=false) {
+    if (key === None) {
+        Array.prototype.sort.call(this)
+    } else {
+        callable = require('../builtins.js').callable
+        if (callable(key)) {
+            // Call using batavia conventions
+            var keyfunc = function(a, b) {
+                return builtins.call(key, [a, b], {})
+            }
+            Array.prototype.sort.call(this, keyfunc)
+        } else {
+            throw new exceptions.TypeError.$pyclass("'" + type_name(key) + "' object is not callable")
+        }
+    }
+    if (reverse) {
+        Array.prototype.reverse.apply(this)
+    }
+    return None
 }
 
 function validateIndexType(index) {

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -745,8 +745,8 @@ List.prototype.sort = function(key=None, reverse=false) {
         callable = require('../builtins.js').callable
         if (callable(key)) {
             // Call using batavia conventions
-            var keyfunc = function(a, b) {
-                return builtins.call(key, [a, b], {})
+            var keyfunc = function(arg) {
+                return builtins.call(key, [arg], {})
             }
             Array.prototype.sort.call(this, keyfunc)
         } else {
@@ -754,7 +754,7 @@ List.prototype.sort = function(key=None, reverse=false) {
         }
     }
     if (reverse) {
-        Array.prototype.reverse.apply(this)
+        Array.prototype.reverse.call(this)
     }
     return None
 }

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -552,7 +552,18 @@ List.prototype.__delitem__ = function(index) {
                 this.splice(idx, 1)
             }
         }
-    } else {
+    } else if (types.isinstance(index, types.Slice)) {
+        var start = index.start
+        var stop = index.stop
+        if (start = None) {
+            start = 0
+        }
+        if (stop = None) {
+            stop = this.length
+        }
+        this.splice(start, stop - start)
+    }
+    else {
         throw new exceptions.TypeError.$pyclass('list indices must be integers, not ' + type_name(index))
     }
 }

--- a/batavia/types/List.js
+++ b/batavia/types/List.js
@@ -555,10 +555,10 @@ List.prototype.__delitem__ = function(index) {
     } else if (types.isinstance(index, types.Slice)) {
         var start = index.start
         var stop = index.stop
-        if (start = None) {
+        if (start === None) {
             start = 0
         }
-        if (stop = None) {
+        if (stop === None) {
             stop = this.length
         }
         this.splice(start, stop - start)

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -9,19 +9,18 @@ class ListTests(TranspileTestCase):
             print(list())
             """)
 
-    @expectedFailure
-    def test_list_with_args(self):
+    def test_list_callable_with_args(self):
         self.assertCodeExecution("""
             print([1, 2, 3])
             print(list((1, 2, 3)))
             try:
+                print(">>> list(1, 2)")
                 list(1, 2)
             except TypeError as e:
                 print(e)
             """)
 
-    @expectedFailure
-    def test_list_with_kwargs(self):
+    def test_list_callable_with_kwargs(self):
         self.assertCodeExecution("""
             try:
                 print(list(a=1))
@@ -50,7 +49,6 @@ class ListTests(TranspileTestCase):
             assert y.copy()[0] is x
             """)
 
-    @expectedFailure
     def test_list_operations(self):
         # Print the result of the method to ensure it returns the correct output, even if None
         # Print the list after every operation to ensure it returns the correct output
@@ -69,12 +67,12 @@ class ListTests(TranspileTestCase):
             print(".reverse: ", a.reverse(), a)
             b = a.copy()
             print(".copy: ", b, a)
-            print(".clear: ".clear(), a)
+            print(".clear: ", a.clear(), a)
             print("Ensure copy is not still linked: ", b)
 
             try:
                 print(a.index(100))
-            except IndexError as e:
+            except ValueError as e:
                 print(e)
 
             print("Empty list tests.")
@@ -99,7 +97,6 @@ class ListTests(TranspileTestCase):
             print(a.copy(), a)
             """)
 
-    @expectedFailure
     def test_slice_operations(self):
         'Credit: https://docs.python.org/3/tutorial/datastructures.html'
 

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -97,24 +97,23 @@ class ListTests(TranspileTestCase):
             print(a.copy(), a)
             """)
 
+    # Credit: https://docs.python.org/3/tutorial/datastructures.html
     def test_slice_operations(self):
-        'Credit: https://docs.python.org/3/tutorial/datastructures.html'
-
         self.assertCodeExecution("""
             a = [1, 5, 3]
 
-            print(a[-1])
-            print(a[-1:])
-            print(a[:-1])
+            print("a[-1] -> ", a[-1])
+            print("a[-1:] -> ", a[-1:])
+            print("a[:-1] -> ", a[:-1])
 
-            a[len(a):] = [1]
-            print("Insert: ", a)
+            # a[len(a):] = [1]
+            # print("a[len(a):] = [1] -> ", a)
 
             del a[0]
-            print("Del one item: ", a)
+            print("del a[0] -> ", a)
 
             del a[:]
-            print("Clear: ", a)
+            print("del a[:] -> ", a)
 
             a = [1, 5, 3]
             del a[1:]

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -9,12 +9,18 @@ class ListTests(TranspileTestCase):
             print(list())
             """)
 
+    @expectedFailure
     def test_list_with_args(self):
         self.assertCodeExecution("""
             print([1, 2, 3])
-            print(list([1, 2, 3], 5, 6))
+            print(list((1, 2, 3)))
+            try:
+                list(1, 2)
+            except TypeError as e:
+                print(e)
             """)
 
+    @expectedFailure
     def test_list_with_kwargs(self):
         self.assertCodeExecution("""
             try:
@@ -35,34 +41,43 @@ class ListTests(TranspileTestCase):
             b = a
             b.append(1)
             print(a)
-            if a != b or a !== b:
-                raise Exception("Test failed. a == b: ", a == b, "a === b", a === b)
+            if a != b or a is not b:
+                raise Exception("Test failed. a == b: ", a == b, "a is b", a is b)
+
+            print("Test shallow copy")
+            x = [1]
+            y = [x]
+            assert y.copy()[0] is x
             """)
 
     @expectedFailure
     def test_list_operations(self):
-
         # Print the result of the method to ensure it returns the correct output, even if None
         # Print the list after every operation to ensure it returns the correct output
         self.assertCodeExecution("""
             a = [5, 2, 4, 3, 1]
 
-            print(a.append(6), a)
-            print(a.extend([8, 9, 10]), a)
-            print(a.insert(2, 3.5), a)
-            print(a.remove(4), a)
-            print(a.pop(), a)
-            print(a.pop(2), a)
-            print(a.index(5))
-            print(a.count(2), a)
-            print(a.sort(key=None, reverse=True), a.sort(key=None, reverse=False), a)
-            print(a.reverse(), a)
+            print(".append: ", a.append(6), a)
+            print(".extend: ", a.extend([8, 9, 10]), a)
+            print(".insert: ", a.insert(2, 3.5), a)
+            print(".remove: ", a.remove(4), a)
+            print(".pop: ", a.pop(), a)
+            print(".pop(index): ", a.pop(2), a)
+            print(".index: ", a.index(5))
+            print(".count: ", [0, 2, 0, 2, 2].count(2))
+            print(".sort: ", a.sort(key=None, reverse=True), a.sort(key=None, reverse=False), a)
+            print(".reverse: ", a.reverse(), a)
             b = a.copy()
-            print(b, a)
-            print(a.clear(), a)
-            print(b)  # ensure b is not still linked to a
+            print(".copy: ", b, a)
+            print(".clear: ".clear(), a)
+            print("Ensure copy is not still linked: ", b)
 
-            # Test empty lists.
+            try:
+                print(a.index(100))
+            except IndexError as e:
+                print(e)
+
+            print("Empty list tests.")
             a = []
             print(a.append(1), a)
             a = []
@@ -84,8 +99,9 @@ class ListTests(TranspileTestCase):
             print(a.copy(), a)
             """)
 
+    @expectedFailure
     def test_slice_operations(self):
-        'Reference: https://docs.python.org/3/tutorial/datastructures.html'
+        'Credit: https://docs.python.org/3/tutorial/datastructures.html'
 
         self.assertCodeExecution("""
             a = [1, 5, 3]
@@ -118,7 +134,7 @@ class ListTests(TranspileTestCase):
         """)
 
     def test_comprehensions(self):
-        'Reference: https://docs.python.org/3/tutorial/datastructures.html'
+        'Credit: https://docs.python.org/3/tutorial/datastructures.html'
         self.assertCodeExecution("""
             matrix = [
                 [1, 2, 3, 4],

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -126,21 +126,25 @@ class ListTests(TranspileTestCase):
                 print(e)
         """)
 
+    @expectedFailure
     def test_insert_with_slice(self):
         self.assertCodeExecution("""
-            a[len(a):] = [1]
+            a = [1, 2, 3]
+            a[len(a):] = [1]  # should append to the end
             print("a[len(a):] = [1] -> ", a)
         """)
 
     def test_sort_with_key(self):
         self.assertCodeExecution("""
-        def key_func(a, b):
-            if a % 2:
-                return True
-            else:
-                return False
+            def key_func(val):
+                return val % 4
 
-        print([1, 2, 3, 4, 5, 6, -1, 27, 33, 155].sort(key=key_func))
+            print([1, 2, 3, 4, 5, 6, -1, 27, 33, 155].sort(key=key_func))
+        """)
+
+    def test_sort_with_reverse(self):
+        self.assertCodeExecution("""
+            print([1, 2, 3].sort(reverse=True))
         """)
 
     def test_comprehensions(self):

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -117,7 +117,7 @@ class ListTests(TranspileTestCase):
 
             a = [1, 5, 3]
             del a[1:]
-            print("Del slice: ", a)
+            print("del a[1:] -> ", a)
 
             # empty lists
             a = []

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -1,8 +1,132 @@
 from .. utils import TranspileTestCase, BuiltinFunctionTestCase
+from unittest import expectedFailure
 
 
 class ListTests(TranspileTestCase):
-    pass
+    def test_list(self):
+        self.assertCodeExecution("""
+            print([])
+            print(list())
+            """)
+
+    def test_list_with_args(self):
+        self.assertCodeExecution("""
+            print([1, 2, 3])
+            print(list([1, 2, 3], 5, 6))
+            """)
+
+    def test_list_with_kwargs(self):
+        self.assertCodeExecution("""
+            try:
+                print(list(a=1))
+            except TypeError as e:
+                print(e)
+            """)
+
+    def test_list_from_tuple(self):
+        self.assertCodeExecution("""
+            t = (1, 2, 3)
+            print(list(t))
+            """)
+
+    def test_list_is_mutable(self):
+        self.assertCodeExecution("""
+            a = []
+            b = a
+            b.append(1)
+            print(a)
+            if a != b or a !== b:
+                raise Exception("Test failed. a == b: ", a == b, "a === b", a === b)
+            """)
+
+    @expectedFailure
+    def test_list_operations(self):
+
+        # Print the result of the method to ensure it returns the correct output, even if None
+        # Print the list after every operation to ensure it returns the correct output
+        self.assertCodeExecution("""
+            a = [5, 2, 4, 3, 1]
+
+            print(a.append(6), a)
+            print(a.extend([8, 9, 10]), a)
+            print(a.insert(2, 3.5), a)
+            print(a.remove(4), a)
+            print(a.pop(), a)
+            print(a.pop(2), a)
+            print(a.index(5))
+            print(a.count(2), a)
+            print(a.sort(key=None, reverse=True), a.sort(key=None, reverse=False), a)
+            print(a.reverse(), a)
+            b = a.copy()
+            print(b, a)
+            print(a.clear(), a)
+            print(b)  # ensure b is not still linked to a
+
+            # Test empty lists.
+            a = []
+            print(a.append(1), a)
+            a = []
+            print(a.extend([]), a)
+            a = []
+            print(a.insert(0, 1), a)
+            a = []
+            print(a.insert(50, 2), a)
+            a = []
+            try:
+                print(a.remove(0), a)
+            except ValueError as e:
+                print(e)
+            a = []
+            print(a.sort(), a)
+            a = []
+            print(a.reverse(), a)
+            a = []
+            print(a.copy(), a)
+            """)
+
+    def test_slice_operations(self):
+        'Reference: https://docs.python.org/3/tutorial/datastructures.html'
+
+        self.assertCodeExecution("""
+            a = [1, 5, 3]
+
+            print(a[-1])
+            print(a[-1:])
+            print(a[:-1])
+
+            a[len(a):] = [1]
+            print("Insert: ", a)
+
+            del a[0]
+            print("Del one item: ", a)
+
+            del a[:]
+            print("Clear: ", a)
+
+            a = [1, 5, 3]
+            del a[1:]
+            print("Del slice: ", a)
+
+            # empty lists
+            a = []
+            print(a[-1:])
+            print(a[:-1])
+            try:
+                print(a[-1])
+            except IndexError as e:
+                print(e)
+        """)
+
+    def test_comprehensions(self):
+        'Reference: https://docs.python.org/3/tutorial/datastructures.html'
+        self.assertCodeExecution("""
+            matrix = [
+                [1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11, 12],
+                ]
+            print([[row[i] for row in matrix] for i in range(4)])
+        """)
 
 
 class BuiltinListFunctionTests(BuiltinFunctionTestCase, TranspileTestCase):

--- a/tests/builtins/test_list.py
+++ b/tests/builtins/test_list.py
@@ -106,9 +106,6 @@ class ListTests(TranspileTestCase):
             print("a[-1:] -> ", a[-1:])
             print("a[:-1] -> ", a[:-1])
 
-            # a[len(a):] = [1]
-            # print("a[len(a):] = [1] -> ", a)
-
             del a[0]
             print("del a[0] -> ", a)
 
@@ -127,6 +124,23 @@ class ListTests(TranspileTestCase):
                 print(a[-1])
             except IndexError as e:
                 print(e)
+        """)
+
+    def test_insert_with_slice(self):
+        self.assertCodeExecution("""
+            a[len(a):] = [1]
+            print("a[len(a):] = [1] -> ", a)
+        """)
+
+    def test_sort_with_key(self):
+        self.assertCodeExecution("""
+        def key_func(a, b):
+            if a % 2:
+                return True
+            else:
+                return False
+
+        print([1, 2, 3, 4, 5, 6, -1, 27, 33, 155].sort(key=key_func))
         """)
 
     def test_comprehensions(self):


### PR DESCRIPTION
Submitting so the test suite can run and I can see what else broke.

List was missing certain pieces of its implementation. I added them and updated the test suite.
- builtins.list() now accepts and properly raises errors for kwargs. (ex. list(a=1) should raise an error)
- List.sort now accepts key functions and the reverse kwarg
- certain issues with slices have been fixed
- various error messages / cleanup / little fixes

To do still:
- At a glance it looked like some error messages were hastily added. Need to go through and add tests for all the possible error cases.
- a[len(a):] = iterable is apparently supposed to append the iterable to the end of the list. I have no clue how to get that syntax to produce the desired result. I broke it out into its own test. (from: https://docs.python.org/3/tutorial/datastructures.html)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
