### PR TITLE
Fixed some broken links in 'docs/how-to' section

### DIFF
--- a/docs/how-to/contribute-code.rst
+++ b/docs/how-to/contribute-code.rst
@@ -9,13 +9,13 @@ what you don’t know!
 
 This tutorial is also going to focus on code contributions. If your interests
 and skills are in documentation, `we have a separate contributors guide
-<contribute-docs>`__ just for you.
+<contribute-docs.rst>`__ just for you.
 
 Do the tutorial first!
 ----------------------
 
 Before you make your first contribution, take Batavia for a spin. The
-instructions in the `getting started guide </tutorial/tutorial-0>`__ *should*
+instructions in the `getting started guide </docs/tutorial/tutorial-0.rst>`__ *should*
 be enough to get going. If you get stuck, that points to your first
 contribution - work out what instructions would have made you *not* get stuck,
 and contribute an update to the README.
@@ -24,7 +24,7 @@ Set up your development environment
 -----------------------------------
 
 Having run the tutorial, you need to `set up your environment for Batavia
-development <development-env>`__. The Batavia development environment is very
+development <development-env.rst>`__. The Batavia development environment is very
 similar to the tutorial environment, but you'll be using your own fork of
 Batavia's source code, rather than the official repository.
 


### PR DESCRIPTION
- Updated the links given in the documentation to the correct destinations.
- The links are directed to the desired pages and 'page not found' errors are eliminated.
- Refs #828 

- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
